### PR TITLE
Fixed the pkg for compatibility with the new version of GevApi + rospy node for img publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ ROS package providing a basic Python API to access DALSA GigE cameras using Open
 The [DALSA GigE-V Framework for Linux](https://www.teledynedalsa.com/imaging/products/software/linux-gige-v/) must be installed. Be sure to run 'corinstall' and then logout/login to fully install the framework.
 
 Interfaces to the GevApi library were generated using [ctypesgen.py](https://github.com/davidjamesca/ctypesgen).
+
+# usage:
+`rosrun rpi_gige_v_framework ros_image_publisher`
+
+or
+
+`rosrun rpi_gige_v_framework ros_image_publisher show_image=true`

--- a/scripts/ros_image_publisher
+++ b/scripts/ros_image_publisher
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import rpi_gige_v_framework as gige
+import cv2
+import sys
+import rospy
+from sensor_msgs.msg import Image
+from cv_bridge import CvBridge, CvBridgeError
+
+def dalsa_publisher():
+    rospy.init_node('ros_image_publisher')
+    camera_frame = rospy.get_param('~dalsa_camera_frame', "dalsa_link")
+    camera_topic = rospy.get_param('~dalsa_camera_topic', "dalsa_camera")
+    show_window = rospy.get_param('~show_window', False)
+    camera_id = rospy.get_param('~camera_id', 0)
+
+    camera_list=gige.GigE_V_VideoCapture.get_camera_list()
+    print(camera_list)
+    
+    cam=gige.GigE_V_VideoCapture()
+    cam.open(camera_id)
+    
+    for i in range(3):
+        #Dump a few frames to clear buffers
+        cam.read()
+
+    bridge = CvBridge()
+    pub = rospy.Publisher(camera_topic, Image, queue_size=10)
+    rate = rospy.Rate(36) #the camera actually works at 35 fps
+    start_publish = True
+    
+    rate = rospy.Rate(36) #the camera actually works at 35 fps
+
+    while not rospy.is_shutdown():
+        res, img=cam.read()    
+        if (show_window):
+            #OpenCV stuff:
+            cv2.imshow('',img)
+            cv2.waitKey(1)
+        #ROS stuff:
+        pub_img = bridge.cv2_to_imgmsg(img, encoding="passthrough")
+        pub_img.header.frame_id = camera_frame
+        pub_img.header.stamp = rospy.Time.now()
+        pub.publish(pub_img)
+
+        rate.sleep() 
+    
+    if (show_window):    
+        cv2.destroyAllWindows() 
+
+    cam.release()
+       
+
+if __name__ == '__main__':
+    try:
+        dalsa_publisher()
+    except rospy.ROSInterruptException:
+        cam.release()
+        pass

--- a/src/rpi_gige_v_framework/gevapi.py
+++ b/src/rpi_gige_v_framework/gevapi.py
@@ -1,7 +1,7 @@
 '''Wrapper for gevapi.h
 
 Generated with:
-/home/wasonj/.local/bin/ctypesgen.py -lGevApi gevapi.h -o gevapi.py
+ctypesgen.py -lGevApi /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h -o gevapi.py
 
 Do not modify this file.
 '''
@@ -594,17 +594,19 @@ _libs["GevApi"] = load_library("GevApi")
 
 # No modules
 
-__time_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 139
+__time_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 148
 
-__suseconds_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 141
+__suseconds_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 150
 
-u_int8_t = c_ubyte # /usr/include/x86_64-linux-gnu/sys/types.h: 173
+u_int8_t = c_ubyte # /usr/include/x86_64-linux-gnu/sys/types.h: 161
 
-u_int16_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 174
+u_int16_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 162
 
-u_int32_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 175
+u_int32_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 163
 
-# /usr/include/x86_64-linux-gnu/bits/time.h: 30
+u_int64_t = c_ulong # /usr/include/x86_64-linux-gnu/sys/types.h: 165
+
+# /usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h: 8
 class struct_timeval(Structure):
     pass
 
@@ -617,9 +619,7 @@ struct_timeval._fields_ = [
     ('tv_usec', __suseconds_t),
 ]
 
-pthread_t = c_ulong # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 60
-
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 75
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 82
 class struct___pthread_internal_list(Structure):
     pass
 
@@ -632,9 +632,9 @@ struct___pthread_internal_list._fields_ = [
     ('__next', POINTER(struct___pthread_internal_list)),
 ]
 
-__pthread_list_t = struct___pthread_internal_list # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 79
+__pthread_list_t = struct___pthread_internal_list # /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 86
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 92
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 118
 class struct___pthread_mutex_s(Structure):
     pass
 
@@ -659,24 +659,43 @@ struct___pthread_mutex_s._fields_ = [
     ('__list', __pthread_list_t),
 ]
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 128
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 151
+class struct___pthread_cond_s(Structure):
+    pass
+
+struct___pthread_cond_s.__slots__ = [
+    '__g_refs',
+    '__g_size',
+    '__g1_orig_size',
+    '__wrefs',
+    '__g_signals',
+]
+struct___pthread_cond_s._fields_ = [
+    ('__g_refs', c_uint * 2),
+    ('__g_size', c_uint * 2),
+    ('__g1_orig_size', c_uint),
+    ('__wrefs', c_uint),
+    ('__g_signals', c_uint * 2),
+]
+
+pthread_t = c_ulong # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 27
+
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 36
 class union_anon_9(Union):
     pass
 
 union_anon_9.__slots__ = [
-    '__data',
     '__size',
     '__align',
 ]
 union_anon_9._fields_ = [
-    ('__data', struct___pthread_mutex_s),
-    ('__size', c_char * 40),
-    ('__align', c_long),
+    ('__size', c_char * 4),
+    ('__align', c_int),
 ]
 
-pthread_mutex_t = union_anon_9 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 128
+pthread_mutexattr_t = union_anon_9 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 36
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 134
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 45
 class union_anon_10(Union):
     pass
 
@@ -689,34 +708,26 @@ union_anon_10._fields_ = [
     ('__align', c_int),
 ]
 
-pthread_mutexattr_t = union_anon_10 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 134
+pthread_condattr_t = union_anon_10 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 45
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 141
-class struct_anon_11(Structure):
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 72
+class union_anon_11(Union):
     pass
 
-struct_anon_11.__slots__ = [
-    '__lock',
-    '__futex',
-    '__total_seq',
-    '__wakeup_seq',
-    '__woken_seq',
-    '__mutex',
-    '__nwaiters',
-    '__broadcast_seq',
+union_anon_11.__slots__ = [
+    '__data',
+    '__size',
+    '__align',
 ]
-struct_anon_11._fields_ = [
-    ('__lock', c_int),
-    ('__futex', c_uint),
-    ('__total_seq', c_ulonglong),
-    ('__wakeup_seq', c_ulonglong),
-    ('__woken_seq', c_ulonglong),
-    ('__mutex', POINTER(None)),
-    ('__nwaiters', c_uint),
-    ('__broadcast_seq', c_uint),
+union_anon_11._fields_ = [
+    ('__data', struct___pthread_mutex_s),
+    ('__size', c_char * 40),
+    ('__align', c_long),
 ]
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 154
+pthread_mutex_t = union_anon_11 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 72
+
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 80
 class union_anon_12(Union):
     pass
 
@@ -726,45 +737,30 @@ union_anon_12.__slots__ = [
     '__align',
 ]
 union_anon_12._fields_ = [
-    ('__data', struct_anon_11),
+    ('__data', struct___pthread_cond_s),
     ('__size', c_char * 48),
     ('__align', c_longlong),
 ]
 
-pthread_cond_t = union_anon_12 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 154
+pthread_cond_t = union_anon_12 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 80
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 160
-class union_anon_13(Union):
-    pass
+UINT8 = u_int8_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 799
 
-union_anon_13.__slots__ = [
-    '__size',
-    '__align',
-]
-union_anon_13._fields_ = [
-    ('__size', c_char * 4),
-    ('__align', c_int),
-]
+UINT16 = u_int16_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 801
 
-pthread_condattr_t = union_anon_13 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 160
+INT32 = c_int32 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 802
 
-UINT8 = u_int8_t # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 799
+UINT32 = u_int32_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 803
 
-INT16 = c_int16 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 800
+UINT64 = u_int64_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 806
 
-UINT16 = u_int16_t # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 801
+BOOL = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/posixcmn.h: 166
 
-INT32 = c_int32 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 802
+enum_anon_89 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 191
 
-UINT32 = u_int32_t # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 803
+MutexType_t = enum_anon_89 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 191
 
-BOOL = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/posixcmn.h: 166
-
-enum_anon_91 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 191
-
-MutexType_t = enum_anon_91 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 191
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 204
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 204
 class struct__CRITICAL_SECTION(Structure):
     pass
 
@@ -791,23 +787,23 @@ struct__CRITICAL_SECTION._fields_ = [
     ('savedThreadCancelState', c_int),
 ]
 
-CRITICAL_SECTION = struct__CRITICAL_SECTION # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 204
+CRITICAL_SECTION = struct__CRITICAL_SECTION # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 204
 
-HANDLE = POINTER(None) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 237
+HANDLE = POINTER(None) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 237
 
-ULONG_PTR = c_ulong # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 844
+ULONG_PTR = c_ulong # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 844
 
-PUINT8 = POINTER(UINT8) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 914
+PUINT8 = POINTER(UINT8) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 914
 
-PUINT32 = POINTER(UINT32) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 918
+PUINT32 = POINTER(UINT32) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 918
 
-BOOL32 = INT32 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 924
+PUINT64 = POINTER(UINT64) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 928
 
-GEV_STATUS = UINT16 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gev_linux.h: 95
+GEV_STATUS = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gev_linux.h: 95
 
-GEVLIB_STATUS = INT16 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gev_linux.h: 96
+GEVLIB_STATUS = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gev_linux.h: 96
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 59
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 59
 class struct__DYNAMIC_FIFO(Structure):
     pass
 
@@ -824,13 +820,13 @@ struct__DYNAMIC_FIFO._fields_ = [
     ('Data', ULONG_PTR * 1),
 ]
 
-PDYNAMIC_FIFO = POINTER(struct__DYNAMIC_FIFO) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 59
+PDYNAMIC_FIFO = POINTER(struct__DYNAMIC_FIFO) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 59
 
-enum_anon_105 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 151
+enum_anon_103 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 151
 
-QueueMode = enum_anon_105 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 151
+QueueMode = enum_anon_103 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 151
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 169
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 169
 class struct__DQUEUE(Structure):
     pass
 
@@ -849,157 +845,215 @@ struct__DQUEUE._fields_ = [
     ('dFifo', PDYNAMIC_FIFO),
 ]
 
-DQUEUE = struct__DQUEUE # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/dynaqueue.h: 169
+DQUEUE = struct__DQUEUE # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/dynaqueue.h: 169
 
-enum_anon_106 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+enum_anon_104 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono8 = 17301505 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono8 = 17301505 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono8Signed = 17301506 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono8Signed = 17301506 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono10 = 17825795 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono10 = 17825795 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono10Packed = 17563652 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono10Packed = 17563652 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono12 = 17825797 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono12 = 17825797 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono12Packed = 17563654 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono12Packed = 17563654 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono14 = 17825829 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono14 = 17825829 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtMono16 = 17825799 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtMono16 = 17825799 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGR8 = 17301512 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGR8 = 17301512 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerRG8 = 17301513 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerRG8 = 17301513 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGB8 = 17301514 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGB8 = 17301514 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerBG8 = 17301515 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerBG8 = 17301515 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGR10 = 17825804 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGR10 = 17825804 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerRG10 = 17825805 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerRG10 = 17825805 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGB10 = 17825806 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGB10 = 17825806 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerBG10 = 17825807 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerBG10 = 17825807 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGR12 = 17825808 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGR10Packed = 17563686 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerRG12 = 17825809 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerRG10Packed = 17563687 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerGB12 = 17825810 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGB10Packed = 17563688 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fMtBayerBG12 = 17825811 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerBG10Packed = 17563689 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB8Packed = 35127316 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGR12 = 17825808 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtBGR8Packed = 35127317 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerRG12 = 17825809 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGBA8Packed = 35651606 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGB12 = 17825810 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtBGRA8Packed = 35651607 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerBG12 = 17825811 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB10Packed = 36700184 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGR12Packed = 17563690 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtBGR10Packed = 36700185 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerRG12Packed = 17563691 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB12Packed = 36700186 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerGB12Packed = 17563692 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtBGR12Packed = 36700187 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fMtBayerBG12Packed = 17563693 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB10V1Packed = 35651612 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB8Packed = 35127316 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB10V2Packed = 35651613 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGR8Packed = 35127317 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtYUV411packed = 34340894 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGBA8Packed = 35651606 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtYUV422packed = 34603039 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGRA8Packed = 35651607 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtYUV444packed = 35127328 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB10Packed = 36700184 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_YUV422_8 = 34603058 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGR10Packed = 36700185 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB8Planar = 35127329 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB12Packed = 36700186 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB10Planar = 36700194 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGR12Packed = 36700187 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB12Planar = 36700195 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB14Packed = 36700254 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmtRGB16Planar = 36700196 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGR14Packed = 36700234 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorBGRG8 = 34603174 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB16Packed = 36700211 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorBGRG10 = 35651753 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGR16Packed = 36700235 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorBGRG10p = 34865322 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGBA16Packed = 37748836 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorBGRG12 = 35651757 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtBGRA16Packed = 37748817 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorBGRG12p = 35127470 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB10V1Packed = 35651612 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorRGBG8 = 34603173 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB10V2Packed = 35651613 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorRGBG10 = 35651751 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtYUV411packed = 34340894 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorRGBG10p = 34865320 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtYUV422packed = 34603039 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorRGBG12 = 35651755 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtYUV444packed = 35127328 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-fmt_PFNC_BiColorRGBG12p = 35127468 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmt_PFNC_YUV422_8 = 34603058 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-enumGevPixelFormat = enum_anon_106 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 231
+fmtRGB8Planar = 35127329 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 253
+fmtRGB10Planar = 36700194 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmtRGB12Planar = 36700195 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmtRGB16Planar = 36700196 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorBGRG8 = 34603174 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorBGRG10 = 35651753 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorBGRG10p = 34865322 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorBGRG12 = 35651757 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorBGRG12p = 35127470 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorRGBG8 = 34603173 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorRGBG10 = 35651751 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorRGBG10p = 34865320 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorRGBG12 = 35651755 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+fmt_PFNC_BiColorRGBG12p = 35127468 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+enumGevPixelFormat = enum_anon_104 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 249
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 272
 if hasattr(_libs['GevApi'], 'GevIsPixelTypeMono'):
     GevIsPixelTypeMono = _libs['GevApi'].GevIsPixelTypeMono
     GevIsPixelTypeMono.argtypes = [UINT32]
     GevIsPixelTypeMono.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 254
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 273
 if hasattr(_libs['GevApi'], 'GevIsPixelTypeRGB'):
     GevIsPixelTypeRGB = _libs['GevApi'].GevIsPixelTypeRGB
     GevIsPixelTypeRGB.argtypes = [UINT32]
     GevIsPixelTypeRGB.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 255
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 274
+if hasattr(_libs['GevApi'], 'GevIsPixelTypeBayer'):
+    GevIsPixelTypeBayer = _libs['GevApi'].GevIsPixelTypeBayer
+    GevIsPixelTypeBayer.argtypes = [UINT32]
+    GevIsPixelTypeBayer.restype = BOOL
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 275
 if hasattr(_libs['GevApi'], 'GevIsPixelTypeCustom'):
     GevIsPixelTypeCustom = _libs['GevApi'].GevIsPixelTypeCustom
     GevIsPixelTypeCustom.argtypes = [UINT32]
     GevIsPixelTypeCustom.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 256
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 276
 if hasattr(_libs['GevApi'], 'GevIsPixelTypePacked'):
     GevIsPixelTypePacked = _libs['GevApi'].GevIsPixelTypePacked
     GevIsPixelTypePacked.argtypes = [UINT32]
     GevIsPixelTypePacked.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 257
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 277
 if hasattr(_libs['GevApi'], 'GevGetPixelSizeInBytes'):
     GevGetPixelSizeInBytes = _libs['GevApi'].GevGetPixelSizeInBytes
     GevGetPixelSizeInBytes.argtypes = [UINT32]
     GevGetPixelSizeInBytes.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 258
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 278
 if hasattr(_libs['GevApi'], 'GevGetPixelDepthInBits'):
     GevGetPixelDepthInBits = _libs['GevApi'].GevGetPixelDepthInBits
     GevGetPixelDepthInBits.argtypes = [UINT32]
     GevGetPixelDepthInBits.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 259
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 279
 if hasattr(_libs['GevApi'], 'GevGetRGBPixelOrder'):
     GevGetRGBPixelOrder = _libs['GevApi'].GevGetRGBPixelOrder
     GevGetRGBPixelOrder.argtypes = [UINT32]
     GevGetRGBPixelOrder.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 260
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 280
+if hasattr(_libs['GevApi'], 'GevGetUnpackedPixelType'):
+    GevGetUnpackedPixelType = _libs['GevApi'].GevGetUnpackedPixelType
+    GevGetUnpackedPixelType.argtypes = [UINT32]
+    GevGetUnpackedPixelType.restype = UINT32
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 281
+if hasattr(_libs['GevApi'], 'GevGetBayerAsRGBPixelType'):
+    GevGetBayerAsRGBPixelType = _libs['GevApi'].GevGetBayerAsRGBPixelType
+    GevGetBayerAsRGBPixelType.argtypes = [UINT32]
+    GevGetBayerAsRGBPixelType.restype = UINT32
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 282
+if hasattr(_libs['GevApi'], 'GevGetPixelComponentCount'):
+    GevGetPixelComponentCount = _libs['GevApi'].GevGetPixelComponentCount
+    GevGetPixelComponentCount.argtypes = [UINT32]
+    GevGetPixelComponentCount.restype = UINT32
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 283
+if hasattr(_libs['GevApi'], 'GevGetConvertedPixelType'):
+    GevGetConvertedPixelType = _libs['GevApi'].GevGetConvertedPixelType
+    GevGetConvertedPixelType.argtypes = [c_int, UINT32]
+    GevGetConvertedPixelType.restype = UINT32
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 285
 if hasattr(_libs['GevApi'], 'GevTranslateRawPixelFormat'):
     GevTranslateRawPixelFormat = _libs['GevApi'].GevTranslateRawPixelFormat
     GevTranslateRawPixelFormat.argtypes = [UINT32, PUINT32, PUINT32, PUINT32]
     GevTranslateRawPixelFormat.restype = GEVLIB_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 261
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 286
 if hasattr(_libs['GevApi'], 'GevGetFormatString'):
     GevGetFormatString = _libs['GevApi'].GevGetFormatString
     GevGetFormatString.argtypes = [UINT32]
@@ -1009,141 +1063,191 @@ if hasattr(_libs['GevApi'], 'GevGetFormatString'):
         GevGetFormatString.restype = String
         GevGetFormatString.errcheck = ReturnString
 
-enum_anon_107 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 270
+enum_anon_105 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 295
 
-GevMonitorMode = 0 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 270
+GevMonitorMode = 0 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 295
 
-GevControlMode = 2 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 270
+GevControlMode = 2 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 295
 
-GevExclusiveMode = 4 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 270
+GevExclusiveMode = 4 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 295
 
-GevAccessMode = enum_anon_107 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 270
+GevAccessMode = enum_anon_105 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 295
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 287
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 313
+class struct_anon_106(Structure):
+    pass
+
+struct_anon_106.__slots__ = [
+    'version',
+    'logLevel',
+    'numRetries',
+    'command_timeout_ms',
+    'discovery_timeout_ms',
+    'enumeration_port',
+    'gvcp_port_range_start',
+    'gvcp_port_range_end',
+    'manual_xml_handling',
+]
+struct_anon_106._fields_ = [
+    ('version', UINT32),
+    ('logLevel', UINT32),
+    ('numRetries', UINT32),
+    ('command_timeout_ms', UINT32),
+    ('discovery_timeout_ms', UINT32),
+    ('enumeration_port', UINT32),
+    ('gvcp_port_range_start', UINT32),
+    ('gvcp_port_range_end', UINT32),
+    ('manual_xml_handling', UINT32),
+]
+
+GEVLIB_CONFIG_OPTIONS = struct_anon_106 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 313
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 302
+class struct_anon_107(Structure):
+    pass
+
+struct_anon_107.__slots__ = [
+    'version',
+    'logLevel',
+    'numRetries',
+    'command_timeout_ms',
+    'discovery_timeout_ms',
+    'enumeration_port',
+    'gvcp_port_range_start',
+    'gvcp_port_range_end',
+    'manual_xml_handling',
+]
+struct_anon_107._fields_ = [
+    ('version', UINT32),
+    ('logLevel', UINT32),
+    ('numRetries', UINT32),
+    ('command_timeout_ms', UINT32),
+    ('discovery_timeout_ms', UINT32),
+    ('enumeration_port', UINT32),
+    ('gvcp_port_range_start', UINT32),
+    ('gvcp_port_range_end', UINT32),
+    ('manual_xml_handling', UINT32),
+]
+
+PGEVLIB_CONFIG_OPTIONS = POINTER(struct_anon_107) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 313
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 332
 class struct_anon_108(Structure):
     pass
 
 struct_anon_108.__slots__ = [
-    'version',
-    'logLevel',
     'numRetries',
     'command_timeout_ms',
-    'discovery_timeout_ms',
-    'enumeration_port',
-    'gvcp_port_range_start',
-    'gvcp_port_range_end',
+    'heartbeat_timeout_ms',
+    'streamPktSize',
+    'streamPktDelay',
+    'streamNumFramesBuffered',
+    'streamMemoryLimitMax',
+    'streamMaxPacketResends',
+    'streamFrame_timeout_ms',
+    'streamThreadAffinity',
+    'serverThreadAffinity',
+    'msgChannel_timeout_ms',
+    'enable_passthru_mode',
 ]
 struct_anon_108._fields_ = [
-    ('version', UINT32),
-    ('logLevel', UINT32),
     ('numRetries', UINT32),
     ('command_timeout_ms', UINT32),
-    ('discovery_timeout_ms', UINT32),
-    ('enumeration_port', UINT32),
-    ('gvcp_port_range_start', UINT32),
-    ('gvcp_port_range_end', UINT32),
+    ('heartbeat_timeout_ms', UINT32),
+    ('streamPktSize', UINT32),
+    ('streamPktDelay', UINT32),
+    ('streamNumFramesBuffered', UINT32),
+    ('streamMemoryLimitMax', UINT32),
+    ('streamMaxPacketResends', UINT32),
+    ('streamFrame_timeout_ms', UINT32),
+    ('streamThreadAffinity', INT32),
+    ('serverThreadAffinity', INT32),
+    ('msgChannel_timeout_ms', UINT32),
+    ('enable_passthru_mode', UINT32),
 ]
 
-GEVLIB_CONFIG_OPTIONS = struct_anon_108 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 287
+GEV_CAMERA_OPTIONS = struct_anon_108 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 332
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 277
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 315
 class struct_anon_109(Structure):
     pass
 
 struct_anon_109.__slots__ = [
-    'version',
-    'logLevel',
     'numRetries',
     'command_timeout_ms',
-    'discovery_timeout_ms',
-    'enumeration_port',
-    'gvcp_port_range_start',
-    'gvcp_port_range_end',
+    'heartbeat_timeout_ms',
+    'streamPktSize',
+    'streamPktDelay',
+    'streamNumFramesBuffered',
+    'streamMemoryLimitMax',
+    'streamMaxPacketResends',
+    'streamFrame_timeout_ms',
+    'streamThreadAffinity',
+    'serverThreadAffinity',
+    'msgChannel_timeout_ms',
+    'enable_passthru_mode',
 ]
 struct_anon_109._fields_ = [
-    ('version', UINT32),
-    ('logLevel', UINT32),
     ('numRetries', UINT32),
     ('command_timeout_ms', UINT32),
-    ('discovery_timeout_ms', UINT32),
-    ('enumeration_port', UINT32),
-    ('gvcp_port_range_start', UINT32),
-    ('gvcp_port_range_end', UINT32),
+    ('heartbeat_timeout_ms', UINT32),
+    ('streamPktSize', UINT32),
+    ('streamPktDelay', UINT32),
+    ('streamNumFramesBuffered', UINT32),
+    ('streamMemoryLimitMax', UINT32),
+    ('streamMaxPacketResends', UINT32),
+    ('streamFrame_timeout_ms', UINT32),
+    ('streamThreadAffinity', INT32),
+    ('serverThreadAffinity', INT32),
+    ('msgChannel_timeout_ms', UINT32),
+    ('enable_passthru_mode', UINT32),
 ]
 
-PGEVLIB_CONFIG_OPTIONS = POINTER(struct_anon_109) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 287
+PGEV_CAMERA_OPTIONS = POINTER(struct_anon_109) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 332
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 303
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 342
 class struct_anon_110(Structure):
     pass
 
 struct_anon_110.__slots__ = [
-    'numRetries',
-    'command_timeout_ms',
-    'heartbeat_timeout_ms',
-    'streamPktSize',
-    'streamPktDelay',
-    'streamNumFramesBuffered',
-    'streamMemoryLimitMax',
-    'streamMaxPacketResends',
-    'streamFrame_timeout_ms',
-    'streamThreadAffinity',
-    'serverThreadAffinity',
-    'msgChannel_timeout_ms',
+    'fIPv6',
+    'ipAddr',
+    'ipAddrLow',
+    'ipAddrHigh',
+    'ifIndex',
 ]
 struct_anon_110._fields_ = [
-    ('numRetries', UINT32),
-    ('command_timeout_ms', UINT32),
-    ('heartbeat_timeout_ms', UINT32),
-    ('streamPktSize', UINT32),
-    ('streamPktDelay', UINT32),
-    ('streamNumFramesBuffered', UINT32),
-    ('streamMemoryLimitMax', UINT32),
-    ('streamMaxPacketResends', UINT32),
-    ('streamFrame_timeout_ms', UINT32),
-    ('streamThreadAffinity', INT32),
-    ('serverThreadAffinity', INT32),
-    ('msgChannel_timeout_ms', UINT32),
+    ('fIPv6', BOOL),
+    ('ipAddr', UINT32),
+    ('ipAddrLow', UINT32),
+    ('ipAddrHigh', UINT32),
+    ('ifIndex', UINT32),
 ]
 
-GEV_CAMERA_OPTIONS = struct_anon_110 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 303
+GEV_NETWORK_INTERFACE = struct_anon_110 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 342
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 289
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 335
 class struct_anon_111(Structure):
     pass
 
 struct_anon_111.__slots__ = [
-    'numRetries',
-    'command_timeout_ms',
-    'heartbeat_timeout_ms',
-    'streamPktSize',
-    'streamPktDelay',
-    'streamNumFramesBuffered',
-    'streamMemoryLimitMax',
-    'streamMaxPacketResends',
-    'streamFrame_timeout_ms',
-    'streamThreadAffinity',
-    'serverThreadAffinity',
-    'msgChannel_timeout_ms',
+    'fIPv6',
+    'ipAddr',
+    'ipAddrLow',
+    'ipAddrHigh',
+    'ifIndex',
 ]
 struct_anon_111._fields_ = [
-    ('numRetries', UINT32),
-    ('command_timeout_ms', UINT32),
-    ('heartbeat_timeout_ms', UINT32),
-    ('streamPktSize', UINT32),
-    ('streamPktDelay', UINT32),
-    ('streamNumFramesBuffered', UINT32),
-    ('streamMemoryLimitMax', UINT32),
-    ('streamMaxPacketResends', UINT32),
-    ('streamFrame_timeout_ms', UINT32),
-    ('streamThreadAffinity', INT32),
-    ('serverThreadAffinity', INT32),
-    ('msgChannel_timeout_ms', UINT32),
+    ('fIPv6', BOOL),
+    ('ipAddr', UINT32),
+    ('ipAddrLow', UINT32),
+    ('ipAddrHigh', UINT32),
+    ('ifIndex', UINT32),
 ]
 
-PGEV_CAMERA_OPTIONS = POINTER(struct_anon_111) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 303
+PGEV_NETWORK_INTERFACE = POINTER(struct_anon_111) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 342
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 312
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 class struct_anon_112(Structure):
     pass
 
@@ -1152,19 +1256,37 @@ struct_anon_112.__slots__ = [
     'ipAddr',
     'ipAddrLow',
     'ipAddrHigh',
-    'ifIndex',
+    'macLow',
+    'macHigh',
+    'host',
+    'mode',
+    'capabilities',
+    'manufacturer',
+    'model',
+    'serial',
+    'version',
+    'username',
 ]
 struct_anon_112._fields_ = [
     ('fIPv6', BOOL),
     ('ipAddr', UINT32),
     ('ipAddrLow', UINT32),
     ('ipAddrHigh', UINT32),
-    ('ifIndex', UINT32),
+    ('macLow', UINT32),
+    ('macHigh', UINT32),
+    ('host', GEV_NETWORK_INTERFACE),
+    ('mode', UINT32),
+    ('capabilities', UINT32),
+    ('manufacturer', c_char * (64 + 1)),
+    ('model', c_char * (64 + 1)),
+    ('serial', c_char * (64 + 1)),
+    ('version', c_char * (64 + 1)),
+    ('username', c_char * (64 + 1)),
 ]
 
-GEV_NETWORK_INTERFACE = struct_anon_112 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 312
+GEV_DEVICE_INTERFACE = struct_anon_112 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 305
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 346
 class struct_anon_113(Structure):
     pass
 
@@ -1173,19 +1295,37 @@ struct_anon_113.__slots__ = [
     'ipAddr',
     'ipAddrLow',
     'ipAddrHigh',
-    'ifIndex',
+    'macLow',
+    'macHigh',
+    'host',
+    'mode',
+    'capabilities',
+    'manufacturer',
+    'model',
+    'serial',
+    'version',
+    'username',
 ]
 struct_anon_113._fields_ = [
     ('fIPv6', BOOL),
     ('ipAddr', UINT32),
     ('ipAddrLow', UINT32),
     ('ipAddrHigh', UINT32),
-    ('ifIndex', UINT32),
+    ('macLow', UINT32),
+    ('macHigh', UINT32),
+    ('host', GEV_NETWORK_INTERFACE),
+    ('mode', UINT32),
+    ('capabilities', UINT32),
+    ('manufacturer', c_char * (64 + 1)),
+    ('model', c_char * (64 + 1)),
+    ('serial', c_char * (64 + 1)),
+    ('version', c_char * (64 + 1)),
+    ('username', c_char * (64 + 1)),
 ]
 
-PGEV_NETWORK_INTERFACE = POINTER(struct_anon_113) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 312
+PGEV_DEVICE_INTERFACE = POINTER(struct_anon_113) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 class struct_anon_114(Structure):
     pass
 
@@ -1222,9 +1362,9 @@ struct_anon_114._fields_ = [
     ('username', c_char * (64 + 1)),
 ]
 
-GEV_DEVICE_INTERFACE = struct_anon_114 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
+GEV_CAMERA_INFO = struct_anon_114 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 316
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 346
 class struct_anon_115(Structure):
     pass
 
@@ -1261,97 +1401,21 @@ struct_anon_115._fields_ = [
     ('username', c_char * (64 + 1)),
 ]
 
-PGEV_DEVICE_INTERFACE = POINTER(struct_anon_115) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
+PGEV_CAMERA_INFO = POINTER(struct_anon_115) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 362
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
-class struct_anon_116(Structure):
-    pass
+GEV_CAMERA_HANDLE = POINTER(None) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 364
 
-struct_anon_116.__slots__ = [
-    'fIPv6',
-    'ipAddr',
-    'ipAddrLow',
-    'ipAddrHigh',
-    'macLow',
-    'macHigh',
-    'host',
-    'mode',
-    'capabilities',
-    'manufacturer',
-    'model',
-    'serial',
-    'version',
-    'username',
-]
-struct_anon_116._fields_ = [
-    ('fIPv6', BOOL),
-    ('ipAddr', UINT32),
-    ('ipAddrLow', UINT32),
-    ('ipAddrHigh', UINT32),
-    ('macLow', UINT32),
-    ('macHigh', UINT32),
-    ('host', GEV_NETWORK_INTERFACE),
-    ('mode', UINT32),
-    ('capabilities', UINT32),
-    ('manufacturer', c_char * (64 + 1)),
-    ('model', c_char * (64 + 1)),
-    ('serial', c_char * (64 + 1)),
-    ('version', c_char * (64 + 1)),
-    ('username', c_char * (64 + 1)),
-]
-
-GEV_CAMERA_INFO = struct_anon_116 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 316
-class struct_anon_117(Structure):
-    pass
-
-struct_anon_117.__slots__ = [
-    'fIPv6',
-    'ipAddr',
-    'ipAddrLow',
-    'ipAddrHigh',
-    'macLow',
-    'macHigh',
-    'host',
-    'mode',
-    'capabilities',
-    'manufacturer',
-    'model',
-    'serial',
-    'version',
-    'username',
-]
-struct_anon_117._fields_ = [
-    ('fIPv6', BOOL),
-    ('ipAddr', UINT32),
-    ('ipAddrLow', UINT32),
-    ('ipAddrHigh', UINT32),
-    ('macLow', UINT32),
-    ('macHigh', UINT32),
-    ('host', GEV_NETWORK_INTERFACE),
-    ('mode', UINT32),
-    ('capabilities', UINT32),
-    ('manufacturer', c_char * (64 + 1)),
-    ('model', c_char * (64 + 1)),
-    ('serial', c_char * (64 + 1)),
-    ('version', c_char * (64 + 1)),
-    ('username', c_char * (64 + 1)),
-]
-
-PGEV_CAMERA_INFO = POINTER(struct_anon_117) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 332
-
-GEV_CAMERA_HANDLE = POINTER(None) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 334
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 class struct__tag_GEVBUF_ENTRY(Structure):
     pass
 
 struct__tag_GEVBUF_ENTRY.__slots__ = [
+    'payload_type',
     'state',
     'status',
     'timestamp_hi',
     'timestamp_lo',
+    'timestamp',
     'recv_size',
     'id',
     'h',
@@ -1363,14 +1427,19 @@ struct__tag_GEVBUF_ENTRY.__slots__ = [
     'd',
     'format',
     'address',
+    'chunk_data',
+    'chunk_size',
+    'filename',
 ]
 struct__tag_GEVBUF_ENTRY._fields_ = [
+    ('payload_type', UINT32),
     ('state', UINT32),
-    ('status', UINT32),
+    ('status', INT32),
     ('timestamp_hi', UINT32),
     ('timestamp_lo', UINT32),
-    ('recv_size', UINT32),
-    ('id', UINT32),
+    ('timestamp', UINT64),
+    ('recv_size', UINT64),
+    ('id', UINT64),
     ('h', UINT32),
     ('w', UINT32),
     ('x_offset', UINT32),
@@ -1380,2012 +1449,1455 @@ struct__tag_GEVBUF_ENTRY._fields_ = [
     ('d', UINT32),
     ('format', UINT32),
     ('address', PUINT8),
+    ('chunk_data', PUINT8),
+    ('chunk_size', UINT32),
+    ('filename', c_char * 256),
 ]
 
-GEVBUF_ENTRY = struct__tag_GEVBUF_ENTRY # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+GEVBUF_ENTRY = struct__tag_GEVBUF_ENTRY # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-PGEVBUF_ENTRY = POINTER(struct__tag_GEVBUF_ENTRY) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+PGEVBUF_ENTRY = POINTER(struct__tag_GEVBUF_ENTRY) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-GEVBUF_HEADER = struct__tag_GEVBUF_ENTRY # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+GEVBUF_HEADER = struct__tag_GEVBUF_ENTRY # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-PGEVBUF_HEADER = POINTER(struct__tag_GEVBUF_ENTRY) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+PGEVBUF_HEADER = POINTER(struct__tag_GEVBUF_ENTRY) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-GEV_BUFFER_OBJECT = struct__tag_GEVBUF_ENTRY # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+GEV_BUFFER_OBJECT = struct__tag_GEVBUF_ENTRY # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-PGEV_BUFFER_OBJECT = POINTER(struct__tag_GEVBUF_ENTRY) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+PGEV_BUFFER_OBJECT = POINTER(struct__tag_GEVBUF_ENTRY) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
 
-enum_anon_118 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 369
+enum_anon_116 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 414
 
-Asynchronous = 0 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 369
+Asynchronous = 0 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 414
 
-SynchronousNextEmpty = 1 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 369
+SynchronousNextEmpty = 1 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 414
 
-GevBufferCyclingMode = enum_anon_118 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 369
+GevBufferCyclingMode = enum_anon_116 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 414
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 388
+GEVTL_CBFUNCTION = CFUNCTYPE(UNCHECKED(None), PGEV_BUFFER_OBJECT, POINTER(None)) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 417
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 438
 class struct__GEVBUF_QUEUE(Structure):
     pass
 
 struct__GEVBUF_QUEUE.__slots__ = [
     'type',
+    'size',
+    'numBuffer',
     'height',
     'width',
     'depth',
-    'size',
-    'numBuffer',
     'lastBuffer',
     'nextBuffer',
     'trashCount',
     'cyclingMode',
     'pEmptyBuffers',
     'pFullBuffers',
+    'trashBuf',
     'pCurBuf',
     'buffer',
 ]
 struct__GEVBUF_QUEUE._fields_ = [
     ('type', UINT32),
+    ('size', UINT64),
+    ('numBuffer', UINT32),
     ('height', UINT32),
     ('width', UINT32),
     ('depth', UINT32),
-    ('size', UINT32),
-    ('numBuffer', UINT32),
     ('lastBuffer', INT32),
     ('nextBuffer', UINT32),
     ('trashCount', UINT32),
     ('cyclingMode', GevBufferCyclingMode),
     ('pEmptyBuffers', POINTER(DQUEUE)),
     ('pFullBuffers', POINTER(DQUEUE)),
+    ('trashBuf', GEVBUF_ENTRY),
     ('pCurBuf', POINTER(GEVBUF_ENTRY)),
     ('buffer', GEVBUF_ENTRY * 1),
 ]
 
-GEV_BUFFER_LIST = struct__GEVBUF_QUEUE # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 388
+GEV_BUFFER_LIST = struct__GEVBUF_QUEUE # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 438
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 399
-class struct_anon_119(Structure):
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 449
+class struct_anon_117(Structure):
     pass
 
-struct_anon_119.__slots__ = [
-    'reserved',
+struct_anon_117.__slots__ = [
     'eventNumber',
     'streamChannelIndex',
     'blockId',
+    'timestamp',
     'timeStampHigh',
     'timeStampLow',
 ]
-struct_anon_119._fields_ = [
-    ('reserved', UINT16),
+struct_anon_117._fields_ = [
     ('eventNumber', UINT16),
     ('streamChannelIndex', UINT16),
-    ('blockId', UINT16),
+    ('blockId', UINT64),
+    ('timestamp', UINT64),
     ('timeStampHigh', UINT32),
     ('timeStampLow', UINT32),
 ]
 
-EVENT_MSG = struct_anon_119 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 399
+EVENT_MSG = struct_anon_117 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 449
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 391
-class struct_anon_120(Structure):
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 441
+class struct_anon_118(Structure):
     pass
 
-struct_anon_120.__slots__ = [
-    'reserved',
+struct_anon_118.__slots__ = [
     'eventNumber',
     'streamChannelIndex',
     'blockId',
+    'timestamp',
     'timeStampHigh',
     'timeStampLow',
 ]
-struct_anon_120._fields_ = [
-    ('reserved', UINT16),
+struct_anon_118._fields_ = [
     ('eventNumber', UINT16),
     ('streamChannelIndex', UINT16),
-    ('blockId', UINT16),
+    ('blockId', UINT64),
+    ('timestamp', UINT64),
     ('timeStampHigh', UINT32),
     ('timeStampLow', UINT32),
 ]
 
-PEVENT_MSG = POINTER(struct_anon_120) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 399
+PEVENT_MSG = POINTER(struct_anon_118) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 449
 
-GEVEVENT_CBFUNCTION = CFUNCTYPE(UNCHECKED(None), PEVENT_MSG, PUINT8, UINT16, POINTER(None)) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 401
+GEVEVENT_CBFUNCTION = CFUNCTYPE(UNCHECKED(None), PEVENT_MSG, PUINT8, UINT16, POINTER(None)) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 451
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 406
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 456
 if hasattr(_libs['GevApi'], 'GevFormatCameraInfo'):
     GevFormatCameraInfo = _libs['GevApi'].GevFormatCameraInfo
     GevFormatCameraInfo.argtypes = [POINTER(GEV_DEVICE_INTERFACE), String, UINT32]
     GevFormatCameraInfo.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 409
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 458
 if hasattr(_libs['GevApi'], 'GevPrint'):
     _func = _libs['GevApi'].GevPrint
     _restype = c_int
     _argtypes = [c_int, String, c_uint, String]
     GevPrint = _variadic_function(_func,_restype,_argtypes)
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 510
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 556
 if hasattr(_libs['GevApi'], 'GevApiInitialize'):
     GevApiInitialize = _libs['GevApi'].GevApiInitialize
     GevApiInitialize.argtypes = []
     GevApiInitialize.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 511
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 557
 if hasattr(_libs['GevApi'], 'GevApiUninitialize'):
     GevApiUninitialize = _libs['GevApi'].GevApiUninitialize
     GevApiUninitialize.argtypes = []
     GevApiUninitialize.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 515
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 561
 if hasattr(_libs['GevApi'], 'GevGetLibraryConfigOptions'):
     GevGetLibraryConfigOptions = _libs['GevApi'].GevGetLibraryConfigOptions
     GevGetLibraryConfigOptions.argtypes = [POINTER(GEVLIB_CONFIG_OPTIONS)]
     GevGetLibraryConfigOptions.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 516
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 562
 if hasattr(_libs['GevApi'], 'GevSetLibraryConfigOptions'):
     GevSetLibraryConfigOptions = _libs['GevApi'].GevSetLibraryConfigOptions
     GevSetLibraryConfigOptions.argtypes = [POINTER(GEVLIB_CONFIG_OPTIONS)]
     GevSetLibraryConfigOptions.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 520
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 566
 if hasattr(_libs['GevApi'], 'GevDeviceCount'):
     GevDeviceCount = _libs['GevApi'].GevDeviceCount
     GevDeviceCount.argtypes = []
     GevDeviceCount.restype = c_int
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 521
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 567
 if hasattr(_libs['GevApi'], 'GevGetCameraList'):
     GevGetCameraList = _libs['GevApi'].GevGetCameraList
     GevGetCameraList.argtypes = [POINTER(GEV_CAMERA_INFO), c_int, POINTER(c_int)]
     GevGetCameraList.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 523
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 569
 if hasattr(_libs['GevApi'], 'GevForceCameraIPAddress'):
     GevForceCameraIPAddress = _libs['GevApi'].GevForceCameraIPAddress
     GevForceCameraIPAddress.argtypes = [UINT32, UINT32, UINT32, UINT32]
     GevForceCameraIPAddress.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 524
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 570
 if hasattr(_libs['GevApi'], 'GevEnumerateNetworkInterfaces'):
     GevEnumerateNetworkInterfaces = _libs['GevApi'].GevEnumerateNetworkInterfaces
     GevEnumerateNetworkInterfaces.argtypes = [POINTER(GEV_NETWORK_INTERFACE), UINT32, PUINT32]
     GevEnumerateNetworkInterfaces.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 528
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 574
 if hasattr(_libs['GevApi'], 'GevEnumerateGevDevices'):
     GevEnumerateGevDevices = _libs['GevApi'].GevEnumerateGevDevices
     GevEnumerateGevDevices.argtypes = [POINTER(GEV_NETWORK_INTERFACE), UINT32, POINTER(GEV_DEVICE_INTERFACE), UINT32, PUINT32]
     GevEnumerateGevDevices.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 531
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 577
 if hasattr(_libs['GevApi'], 'GevSetCameraList'):
     GevSetCameraList = _libs['GevApi'].GevSetCameraList
     GevSetCameraList.argtypes = [POINTER(GEV_CAMERA_INFO), c_int]
     GevSetCameraList.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 535
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 581
 if hasattr(_libs['GevApi'], 'GevOpenCamera'):
     GevOpenCamera = _libs['GevApi'].GevOpenCamera
     GevOpenCamera.argtypes = [POINTER(GEV_CAMERA_INFO), GevAccessMode, POINTER(GEV_CAMERA_HANDLE)]
     GevOpenCamera.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 536
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 582
 if hasattr(_libs['GevApi'], 'GevOpenCameraByAddress'):
     GevOpenCameraByAddress = _libs['GevApi'].GevOpenCameraByAddress
     GevOpenCameraByAddress.argtypes = [c_ulong, GevAccessMode, POINTER(GEV_CAMERA_HANDLE)]
     GevOpenCameraByAddress.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 537
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 583
 if hasattr(_libs['GevApi'], 'GevOpenCameraByName'):
     GevOpenCameraByName = _libs['GevApi'].GevOpenCameraByName
     GevOpenCameraByName.argtypes = [String, GevAccessMode, POINTER(GEV_CAMERA_HANDLE)]
     GevOpenCameraByName.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 538
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 584
 if hasattr(_libs['GevApi'], 'GevOpenCameraBySN'):
     GevOpenCameraBySN = _libs['GevApi'].GevOpenCameraBySN
     GevOpenCameraBySN.argtypes = [String, GevAccessMode, POINTER(GEV_CAMERA_HANDLE)]
     GevOpenCameraBySN.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 540
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 586
 if hasattr(_libs['GevApi'], 'GevCloseCamera'):
     GevCloseCamera = _libs['GevApi'].GevCloseCamera
     GevCloseCamera.argtypes = [POINTER(GEV_CAMERA_HANDLE)]
     GevCloseCamera.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 542
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 588
+if hasattr(_libs['GevApi'], 'Gev_Reconnect'):
+    Gev_Reconnect = _libs['GevApi'].Gev_Reconnect
+    Gev_Reconnect.argtypes = [GEV_CAMERA_HANDLE]
+    Gev_Reconnect.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 590
 if hasattr(_libs['GevApi'], 'GevGetCameraInfo'):
     GevGetCameraInfo = _libs['GevApi'].GevGetCameraInfo
     GevGetCameraInfo.argtypes = [GEV_CAMERA_HANDLE]
     GevGetCameraInfo.restype = POINTER(GEV_CAMERA_INFO)
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 544
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 592
 if hasattr(_libs['GevApi'], 'GevGetCameraInterfaceOptions'):
     GevGetCameraInterfaceOptions = _libs['GevApi'].GevGetCameraInterfaceOptions
     GevGetCameraInterfaceOptions.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_CAMERA_OPTIONS)]
     GevGetCameraInterfaceOptions.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 545
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 593
 if hasattr(_libs['GevApi'], 'GevSetCameraInterfaceOptions'):
     GevSetCameraInterfaceOptions = _libs['GevApi'].GevSetCameraInterfaceOptions
     GevSetCameraInterfaceOptions.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_CAMERA_OPTIONS)]
     GevSetCameraInterfaceOptions.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 549
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 597
 if hasattr(_libs['GevApi'], 'Gev_RetrieveXMLData'):
     Gev_RetrieveXMLData = _libs['GevApi'].Gev_RetrieveXMLData
     Gev_RetrieveXMLData.argtypes = [GEV_CAMERA_HANDLE, c_int, String, POINTER(c_int), POINTER(c_int)]
     Gev_RetrieveXMLData.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 550
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 598
 if hasattr(_libs['GevApi'], 'Gev_RetrieveXMLFile'):
     Gev_RetrieveXMLFile = _libs['GevApi'].Gev_RetrieveXMLFile
     Gev_RetrieveXMLFile.argtypes = [GEV_CAMERA_HANDLE, String, c_int, BOOL]
     Gev_RetrieveXMLFile.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 554
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 602
 if hasattr(_libs['GevApi'], 'GevConnectFeatures'):
     GevConnectFeatures = _libs['GevApi'].GevConnectFeatures
     GevConnectFeatures.argtypes = [GEV_CAMERA_HANDLE, POINTER(None)]
     GevConnectFeatures.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 555
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 603
 if hasattr(_libs['GevApi'], 'GevGetFeatureNodeMap'):
     GevGetFeatureNodeMap = _libs['GevApi'].GevGetFeatureNodeMap
     GevGetFeatureNodeMap.argtypes = [GEV_CAMERA_HANDLE]
     GevGetFeatureNodeMap.restype = POINTER(None)
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 559
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 607
 if hasattr(_libs['GevApi'], 'GevGetGenICamXML_FileName'):
     GevGetGenICamXML_FileName = _libs['GevApi'].GevGetGenICamXML_FileName
     GevGetGenICamXML_FileName.argtypes = [GEV_CAMERA_HANDLE, c_int, String]
     GevGetGenICamXML_FileName.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 560
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 608
 if hasattr(_libs['GevApi'], 'GevInitGenICamXMLFeatures'):
     GevInitGenICamXMLFeatures = _libs['GevApi'].GevInitGenICamXMLFeatures
     GevInitGenICamXMLFeatures.argtypes = [GEV_CAMERA_HANDLE, BOOL]
     GevInitGenICamXMLFeatures.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 561
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 609
 if hasattr(_libs['GevApi'], 'GevInitGenICamXMLFeatures_FromFile'):
     GevInitGenICamXMLFeatures_FromFile = _libs['GevApi'].GevInitGenICamXMLFeatures_FromFile
     GevInitGenICamXMLFeatures_FromFile.argtypes = [GEV_CAMERA_HANDLE, String]
     GevInitGenICamXMLFeatures_FromFile.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 562
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 610
 if hasattr(_libs['GevApi'], 'GevInitGenICamXMLFeatures_FromData'):
     GevInitGenICamXMLFeatures_FromData = _libs['GevApi'].GevInitGenICamXMLFeatures_FromData
     GevInitGenICamXMLFeatures_FromData.argtypes = [GEV_CAMERA_HANDLE, c_int, POINTER(None)]
     GevInitGenICamXMLFeatures_FromData.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 564
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 612
 if hasattr(_libs['GevApi'], 'GevGetFeatureValue'):
     GevGetFeatureValue = _libs['GevApi'].GevGetFeatureValue
     GevGetFeatureValue.argtypes = [GEV_CAMERA_HANDLE, String, POINTER(c_int), c_int, POINTER(None)]
     GevGetFeatureValue.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 565
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 613
 if hasattr(_libs['GevApi'], 'GevSetFeatureValue'):
     GevSetFeatureValue = _libs['GevApi'].GevSetFeatureValue
     GevSetFeatureValue.argtypes = [GEV_CAMERA_HANDLE, String, c_int, POINTER(None)]
     GevSetFeatureValue.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 566
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 614
 if hasattr(_libs['GevApi'], 'GevGetFeatureValueAsString'):
     GevGetFeatureValueAsString = _libs['GevApi'].GevGetFeatureValueAsString
     GevGetFeatureValueAsString.argtypes = [GEV_CAMERA_HANDLE, String, POINTER(c_int), c_int, String]
     GevGetFeatureValueAsString.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 567
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 615
 if hasattr(_libs['GevApi'], 'GevSetFeatureValueAsString'):
     GevSetFeatureValueAsString = _libs['GevApi'].GevSetFeatureValueAsString
     GevSetFeatureValueAsString.argtypes = [GEV_CAMERA_HANDLE, String, String]
     GevSetFeatureValueAsString.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 571
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 620
+if hasattr(_libs['GevApi'], 'GevInitializeTransfer'):
+    GevInitializeTransfer = _libs['GevApi'].GevInitializeTransfer
+    GevInitializeTransfer.argtypes = [GEV_CAMERA_HANDLE, GevBufferCyclingMode, UINT64, UINT32, POINTER(POINTER(UINT8))]
+    GevInitializeTransfer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 621
+if hasattr(_libs['GevApi'], 'GevFreeTransfer'):
+    GevFreeTransfer = _libs['GevApi'].GevFreeTransfer
+    GevFreeTransfer.argtypes = [GEV_CAMERA_HANDLE]
+    GevFreeTransfer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 622
+if hasattr(_libs['GevApi'], 'GevGetPayloadParameters'):
+    GevGetPayloadParameters = _libs['GevApi'].GevGetPayloadParameters
+    GevGetPayloadParameters.argtypes = [GEV_CAMERA_HANDLE, PUINT64, PUINT32]
+    GevGetPayloadParameters.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 624
+if hasattr(_libs['GevApi'], 'GevStartTransfer'):
+    GevStartTransfer = _libs['GevApi'].GevStartTransfer
+    GevStartTransfer.argtypes = [GEV_CAMERA_HANDLE, UINT32]
+    GevStartTransfer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 625
+if hasattr(_libs['GevApi'], 'GevStopTransfer'):
+    GevStopTransfer = _libs['GevApi'].GevStopTransfer
+    GevStopTransfer.argtypes = [GEV_CAMERA_HANDLE]
+    GevStopTransfer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 626
+if hasattr(_libs['GevApi'], 'GevAbortTransfer'):
+    GevAbortTransfer = _libs['GevApi'].GevAbortTransfer
+    GevAbortTransfer.argtypes = [GEV_CAMERA_HANDLE]
+    GevAbortTransfer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 628
+if hasattr(_libs['GevApi'], 'GevQueryTransferStatus'):
+    GevQueryTransferStatus = _libs['GevApi'].GevQueryTransferStatus
+    GevQueryTransferStatus.argtypes = [GEV_CAMERA_HANDLE, PUINT32, PUINT32, PUINT32, PUINT32, POINTER(GevBufferCyclingMode)]
+    GevQueryTransferStatus.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 629
+if hasattr(_libs['GevApi'], 'GevWaitForNextFrame'):
+    GevWaitForNextFrame = _libs['GevApi'].GevWaitForNextFrame
+    GevWaitForNextFrame.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(GEV_BUFFER_OBJECT)), UINT32]
+    GevWaitForNextFrame.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 630
+if hasattr(_libs['GevApi'], 'GevGetNextFrame'):
+    GevGetNextFrame = _libs['GevApi'].GevGetNextFrame
+    GevGetNextFrame.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(GEV_BUFFER_OBJECT)), POINTER(struct_timeval)]
+    GevGetNextFrame.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 632
+if hasattr(_libs['GevApi'], 'GevReleaseFrame'):
+    GevReleaseFrame = _libs['GevApi'].GevReleaseFrame
+    GevReleaseFrame.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_BUFFER_OBJECT)]
+    GevReleaseFrame.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 633
+if hasattr(_libs['GevApi'], 'GevReleaseFrameBuffer'):
+    GevReleaseFrameBuffer = _libs['GevApi'].GevReleaseFrameBuffer
+    GevReleaseFrameBuffer.argtypes = [GEV_CAMERA_HANDLE, POINTER(None)]
+    GevReleaseFrameBuffer.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 637
 if hasattr(_libs['GevApi'], 'GevGetImageParameters'):
     GevGetImageParameters = _libs['GevApi'].GevGetImageParameters
     GevGetImageParameters.argtypes = [GEV_CAMERA_HANDLE, PUINT32, PUINT32, PUINT32, PUINT32, PUINT32]
     GevGetImageParameters.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 572
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 638
 if hasattr(_libs['GevApi'], 'GevSetImageParameters'):
     GevSetImageParameters = _libs['GevApi'].GevSetImageParameters
     GevSetImageParameters.argtypes = [GEV_CAMERA_HANDLE, UINT32, UINT32, UINT32, UINT32, UINT32]
     GevSetImageParameters.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 574
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 640
 if hasattr(_libs['GevApi'], 'GevInitImageTransfer'):
     GevInitImageTransfer = _libs['GevApi'].GevInitImageTransfer
     GevInitImageTransfer.argtypes = [GEV_CAMERA_HANDLE, GevBufferCyclingMode, UINT32, POINTER(POINTER(UINT8))]
     GevInitImageTransfer.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 575
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 641
 if hasattr(_libs['GevApi'], 'GevInitializeImageTransfer'):
     GevInitializeImageTransfer = _libs['GevApi'].GevInitializeImageTransfer
     GevInitializeImageTransfer.argtypes = [GEV_CAMERA_HANDLE, UINT32, POINTER(POINTER(UINT8))]
     GevInitializeImageTransfer.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 576
-if hasattr(_libs['GevApi'], 'GevFreeImageTransfer'):
-    GevFreeImageTransfer = _libs['GevApi'].GevFreeImageTransfer
-    GevFreeImageTransfer.argtypes = [GEV_CAMERA_HANDLE]
-    GevFreeImageTransfer.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 577
-if hasattr(_libs['GevApi'], 'GevStartImageTransfer'):
-    GevStartImageTransfer = _libs['GevApi'].GevStartImageTransfer
-    GevStartImageTransfer.argtypes = [GEV_CAMERA_HANDLE, UINT32]
-    GevStartImageTransfer.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 578
-if hasattr(_libs['GevApi'], 'GevStopImageTransfer'):
-    GevStopImageTransfer = _libs['GevApi'].GevStopImageTransfer
-    GevStopImageTransfer.argtypes = [GEV_CAMERA_HANDLE]
-    GevStopImageTransfer.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 579
-if hasattr(_libs['GevApi'], 'GevAbortImageTransfer'):
-    GevAbortImageTransfer = _libs['GevApi'].GevAbortImageTransfer
-    GevAbortImageTransfer.argtypes = [GEV_CAMERA_HANDLE]
-    GevAbortImageTransfer.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 581
-if hasattr(_libs['GevApi'], 'GevQueryImageTransferStatus'):
-    GevQueryImageTransferStatus = _libs['GevApi'].GevQueryImageTransferStatus
-    GevQueryImageTransferStatus.argtypes = [GEV_CAMERA_HANDLE, PUINT32, PUINT32, PUINT32, PUINT32, POINTER(GevBufferCyclingMode)]
-    GevQueryImageTransferStatus.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 582
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 650
 if hasattr(_libs['GevApi'], 'GetPixelSizeInBytes'):
     GetPixelSizeInBytes = _libs['GevApi'].GetPixelSizeInBytes
     GetPixelSizeInBytes.argtypes = [UINT32]
     GetPixelSizeInBytes.restype = c_int
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 585
-for _lib in _libs.itervalues():
-    if not hasattr(_lib, 'GevResetImageTransfer'):
-        continue
-    GevResetImageTransfer = _lib.GevResetImageTransfer
-    GevResetImageTransfer.argtypes = [GEV_CAMERA_HANDLE]
-    GevResetImageTransfer.restype = GEV_STATUS
-    break
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 588
-if hasattr(_libs['GevApi'], 'GevGetNextImage'):
-    GevGetNextImage = _libs['GevApi'].GevGetNextImage
-    GevGetNextImage.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(GEV_BUFFER_OBJECT)), POINTER(struct_timeval)]
-    GevGetNextImage.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 589
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 653
 if hasattr(_libs['GevApi'], 'GevGetImageBuffer'):
     GevGetImageBuffer = _libs['GevApi'].GevGetImageBuffer
     GevGetImageBuffer.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(None))]
     GevGetImageBuffer.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 590
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 654
 if hasattr(_libs['GevApi'], 'GevGetImage'):
     GevGetImage = _libs['GevApi'].GevGetImage
     GevGetImage.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(GEV_BUFFER_OBJECT))]
     GevGetImage.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 591
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 655
 if hasattr(_libs['GevApi'], 'GevWaitForNextImageBuffer'):
     GevWaitForNextImageBuffer = _libs['GevApi'].GevWaitForNextImageBuffer
     GevWaitForNextImageBuffer.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(None)), UINT32]
     GevWaitForNextImageBuffer.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 592
-if hasattr(_libs['GevApi'], 'GevWaitForNextImage'):
-    GevWaitForNextImage = _libs['GevApi'].GevWaitForNextImage
-    GevWaitForNextImage.argtypes = [GEV_CAMERA_HANDLE, POINTER(POINTER(GEV_BUFFER_OBJECT)), UINT32]
-    GevWaitForNextImage.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 594
-if hasattr(_libs['GevApi'], 'GevReleaseImage'):
-    GevReleaseImage = _libs['GevApi'].GevReleaseImage
-    GevReleaseImage.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_BUFFER_OBJECT)]
-    GevReleaseImage.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 595
-if hasattr(_libs['GevApi'], 'GevReleaseImageBuffer'):
-    GevReleaseImageBuffer = _libs['GevApi'].GevReleaseImageBuffer
-    GevReleaseImageBuffer.argtypes = [GEV_CAMERA_HANDLE, POINTER(None)]
-    GevReleaseImageBuffer.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 599
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 664
 if hasattr(_libs['GevApi'], 'GevRegisterEventCallback'):
     GevRegisterEventCallback = _libs['GevApi'].GevRegisterEventCallback
     GevRegisterEventCallback.argtypes = [GEV_CAMERA_HANDLE, UINT32, GEVEVENT_CBFUNCTION, POINTER(None)]
     GevRegisterEventCallback.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 600
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 665
 if hasattr(_libs['GevApi'], 'GevRegisterApplicationEvent'):
     GevRegisterApplicationEvent = _libs['GevApi'].GevRegisterApplicationEvent
     GevRegisterApplicationEvent.argtypes = [GEV_CAMERA_HANDLE, UINT32, HANDLE]
     GevRegisterApplicationEvent.restype = GEV_STATUS
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 601
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 666
 if hasattr(_libs['GevApi'], 'GevUnregisterEvent'):
     GevUnregisterEvent = _libs['GevApi'].GevUnregisterEvent
     GevUnregisterEvent.argtypes = [GEV_CAMERA_HANDLE, UINT32]
     GevUnregisterEvent.restype = GEV_STATUS
 
-enum_anon_121 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraUnknown = 0 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraGenieMono = 1 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraGenieColor = 2 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraGenieHM = 3 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraDracoBased = 4 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraSpyder3SG114K = 5 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraSpyder3SG111K = 6 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraSpyder3SG144K = 7 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraSpyder3SG324K = 8 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraSpyder3SG344K = 9 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraGenieTS = 10 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraXMLBased = 11 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-cameraType = enum_anon_121 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 627
-
-PGENICAM_FEATURE = POINTER(None) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 637
-
-enum_anon_122 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 644
-
-RO = 1 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 644
-
-WO = 2 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 644
-
-RW = 3 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 644
-
-RegAccess = enum_anon_122 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 644
-
-enum_anon_123 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-stringReg = 0 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-floatReg = (stringReg + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-integerReg = (floatReg + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-bitReg = (integerReg + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-fixedVal = (bitReg + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-intVal = (fixedVal + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-floatVal = (intVal + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-dataArea = (floatVal + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-floatRegLE = (dataArea + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-integerRegLE = (floatRegLE + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-bitRegLE = (integerRegLE + 1) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-RegType = enum_anon_123 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 659
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 665
-class struct_anon_124(Structure):
-    pass
-
-struct_anon_124.__slots__ = [
-    'name',
-    'value',
-]
-struct_anon_124._fields_ = [
-    ('name', c_char * 64),
-    ('value', UINT32),
-]
-
-ENUM_ENTRY = struct_anon_124 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 665
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 661
-class struct_anon_125(Structure):
-    pass
-
-struct_anon_125.__slots__ = [
-    'name',
-    'value',
-]
-struct_anon_125._fields_ = [
-    ('name', c_char * 64),
-    ('value', UINT32),
-]
-
-PENUM_ENTRY = POINTER(struct_anon_125) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 665
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 672
-class union_anon_126(Union):
-    pass
-
-union_anon_126.__slots__ = [
-    'bitIndex',
-    'intValue',
-    'floatValue',
-]
-union_anon_126._fields_ = [
-    ('bitIndex', UINT32),
-    ('intValue', UINT32),
-    ('floatValue', c_float),
-]
-
-GENIREG_VALUE = union_anon_126 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 672
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 695
-class struct_anon_127(Structure):
-    pass
-
-struct_anon_127.__slots__ = [
-    'featureName',
-    'address',
-    'accessMode',
-    'available',
-    'type',
-    'regSize',
-    'regStride',
-    'minSelector',
-    'maxSelector',
-    'value',
-    'minValue',
-    'maxValue',
-    'readMask',
-    'writeMask',
-    'feature',
-    'selectorName',
-    'indexName',
-]
-struct_anon_127._fields_ = [
-    ('featureName', c_char * 64),
-    ('address', UINT32),
-    ('accessMode', RegAccess),
-    ('available', BOOL32),
-    ('type', RegType),
-    ('regSize', UINT32),
-    ('regStride', UINT32),
-    ('minSelector', UINT32),
-    ('maxSelector', UINT32),
-    ('value', GENIREG_VALUE),
-    ('minValue', GENIREG_VALUE),
-    ('maxValue', GENIREG_VALUE),
-    ('readMask', UINT32),
-    ('writeMask', UINT32),
-    ('feature', PGENICAM_FEATURE),
-    ('selectorName', c_char * 64),
-    ('indexName', c_char * 64),
-]
-
-GEV_REGISTER = struct_anon_127 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 695
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 676
-class struct_anon_128(Structure):
-    pass
-
-struct_anon_128.__slots__ = [
-    'featureName',
-    'address',
-    'accessMode',
-    'available',
-    'type',
-    'regSize',
-    'regStride',
-    'minSelector',
-    'maxSelector',
-    'value',
-    'minValue',
-    'maxValue',
-    'readMask',
-    'writeMask',
-    'feature',
-    'selectorName',
-    'indexName',
-]
-struct_anon_128._fields_ = [
-    ('featureName', c_char * 64),
-    ('address', UINT32),
-    ('accessMode', RegAccess),
-    ('available', BOOL32),
-    ('type', RegType),
-    ('regSize', UINT32),
-    ('regStride', UINT32),
-    ('minSelector', UINT32),
-    ('maxSelector', UINT32),
-    ('value', GENIREG_VALUE),
-    ('minValue', GENIREG_VALUE),
-    ('maxValue', GENIREG_VALUE),
-    ('readMask', UINT32),
-    ('writeMask', UINT32),
-    ('feature', PGENICAM_FEATURE),
-    ('selectorName', c_char * 64),
-    ('indexName', c_char * 64),
-]
-
-PGEV_REGISTER = POINTER(struct_anon_128) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 695
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 953
-class struct_anon_129(Structure):
-    pass
-
-struct_anon_129.__slots__ = [
-    'DeviceVendorName',
-    'DeviceModelName',
-    'DeviceVersion',
-    'DeviceFirmwareVersion',
-    'DeviceID',
-    'DeviceUserID',
-    'DeviceScanType',
-    'DeviceMaxThroughput',
-    'DeviceRegistersStreamingStart',
-    'DeviceRegistersStreamingEnd',
-    'DeviceRegistersCheck',
-    'DeviceRegistersValid',
-    'SensorWidth',
-    'SensorHeight',
-    'WidthMax',
-    'HeightMax',
-    'Width',
-    'Height',
-    'OffsetX',
-    'OffsetY',
-    'LinePitch',
-    'BinningHorizontal',
-    'BinningVertical',
-    'DecimationHorizontal',
-    'DecimationVertical',
-    'ReverseX',
-    'ReverseY',
-    'PixelColorFilter',
-    'PixelCoding',
-    'PixelSize',
-    'PixelFormat',
-    'PixelDynamicRangeMin',
-    'PixelDynamicRangeMax',
-    'TestImageSelector',
-    'AcquisitionMode',
-    'AcquisitionStart',
-    'AcquisitionStop',
-    'AcquisitionAbort',
-    'AcquisitionArm',
-    'AcquisitionFrameCount',
-    'AcquisitionFrameRateMax',
-    'AcquisitionFrameRateMin',
-    'AcquisitionFrameRateRaw',
-    'AcquisitionFrameRateAbs',
-    'AcquisitionLineRateRaw',
-    'AcquisitionLineRateAbs',
-    'AcquisitionStatusSelector',
-    'AcquisitionStatus',
-    'TriggerSelector',
-    'TriggerMode',
-    'TriggerSoftware',
-    'TriggerSource',
-    'TriggerActivation',
-    'TriggerOverlap',
-    'TriggerDelayAbs',
-    'TriggerDelayRaw',
-    'TriggerDivider',
-    'TriggerMultiplier',
-    'ExposureMode',
-    'ExposureAlignment',
-    'ExposureDelay',
-    'ExposureTimeRaw',
-    'ExposureTimeAbs',
-    'ExposureAuto',
-    'ExposureTimeMin',
-    'ExposureTimeMax',
-    'LineSelector',
-    'LineMode',
-    'LineInverter',
-    'LineStatus',
-    'LineStatusAll',
-    'LineSource',
-    'OutputLineEventSource',
-    'LineFormat',
-    'UserOutputValue',
-    'OutputLineValue',
-    'UserOutputSelector',
-    'UserOutputValueAll',
-    'UserOutputValueAllMask',
-    'InputLinePolarity',
-    'InputLineDebouncingPeriod',
-    'OutputLinePulsePolarity',
-    'OutputLineMode',
-    'OutputLinePulseDelay',
-    'OutputLinePulseDuration',
-    'CounterSelector',
-    'CounterEventSource',
-    'CounterLineSource',
-    'CounterReset',
-    'CounterValue',
-    'CounterValueAtReset',
-    'CounterDuration',
-    'CounterStatus',
-    'CounterTriggerSource',
-    'CounterTriggerActivation',
-    'TimerSelector',
-    'TimerDurationAbs',
-    'TimerDurationRaw',
-    'TimerDelayAbs',
-    'TimerDelayRaw',
-    'TimerValueAbs',
-    'TimerValueRaw',
-    'TimerStatus',
-    'TimerTriggerSource',
-    'TimerTriggerActivation',
-    'EventSelector',
-    'EventNotification',
-    'GainSelector',
-    'GainRaw',
-    'GainAbs',
-    'GainAuto',
-    'GainAutoBalance',
-    'BlackLevelSelector',
-    'BlackLevelRaw',
-    'BlackLevelAbs',
-    'BlackLevelAuto',
-    'BlackLevelAutoBalance',
-    'WhiteClipSelector',
-    'WhiteClipRaw',
-    'WhiteClipAbs',
-    'BalanceRatioSelector',
-    'BalanceRatioAbs',
-    'BalanceWhiteAuto',
-    'Gamma',
-    'LUTSelector',
-    'LUTEnable',
-    'LUTIndex',
-    'LUTValue',
-    'LUTValueAll',
-    'UserSetDefaultSelector',
-    'UserSetSelector',
-    'UserSetLoad',
-    'UserSetSave',
-    'PayloadSize',
-    'GevSupportedIPConfigurationLLA',
-    'GevSupportedIPConfigurationDHCP',
-    'GevSupportedIPConfigurationPersistentIP',
-    'GevCurrentIPConfigurationLLA',
-    'GevCurrentIPConfigurationDHCP',
-    'GevCurrentIPConfigurationPersistentIP',
-    'GevCurrentIPConfiguration',
-    'GevCurrentIPAddress',
-    'GevCurrentSubnetMask',
-    'GevCurrentDefaultGateway',
-    'GevPersistentIPAddress',
-    'GevPersistentSubnetMask',
-    'GevPersistentDefaultGateway',
-    'GevFirstURL',
-    'GevSecondURL',
-    'GevNumberOfInterfaces',
-    'GevLinkSpeed',
-    'GevIPConfigurationStatus',
-    'ChunkModeActive',
-    'ChunkSelector',
-    'ChunkEnable',
-    'ChunkOffsetX',
-    'ChunkOffsetY',
-    'ChunkWidth',
-    'ChunkHeight',
-    'ChunkPixelFormat',
-    'ChunkDynamicRangeMax',
-    'ChunkDynamicRangeMin',
-    'ChunkTimestamp',
-    'ChunkLineStatusAll',
-    'ChunkCounterSelector',
-    'ChunkCounter',
-    'ChunkTimerSelector',
-    'ChunkTimer',
-    'FileSelector',
-    'FileOperationSelector',
-    'FileOperationExecute',
-    'FileOpenModeSelector',
-    'FileAccessOffset',
-    'FileAccessLength',
-    'FileAccessBuffer',
-    'FileOperationStatus',
-    'FileOperationResult',
-    'FileSize',
-]
-struct_anon_129._fields_ = [
-    ('DeviceVendorName', GEV_REGISTER),
-    ('DeviceModelName', GEV_REGISTER),
-    ('DeviceVersion', GEV_REGISTER),
-    ('DeviceFirmwareVersion', GEV_REGISTER),
-    ('DeviceID', GEV_REGISTER),
-    ('DeviceUserID', GEV_REGISTER),
-    ('DeviceScanType', GEV_REGISTER),
-    ('DeviceMaxThroughput', GEV_REGISTER),
-    ('DeviceRegistersStreamingStart', GEV_REGISTER),
-    ('DeviceRegistersStreamingEnd', GEV_REGISTER),
-    ('DeviceRegistersCheck', GEV_REGISTER),
-    ('DeviceRegistersValid', GEV_REGISTER),
-    ('SensorWidth', GEV_REGISTER),
-    ('SensorHeight', GEV_REGISTER),
-    ('WidthMax', GEV_REGISTER),
-    ('HeightMax', GEV_REGISTER),
-    ('Width', GEV_REGISTER),
-    ('Height', GEV_REGISTER),
-    ('OffsetX', GEV_REGISTER),
-    ('OffsetY', GEV_REGISTER),
-    ('LinePitch', GEV_REGISTER),
-    ('BinningHorizontal', GEV_REGISTER),
-    ('BinningVertical', GEV_REGISTER),
-    ('DecimationHorizontal', GEV_REGISTER),
-    ('DecimationVertical', GEV_REGISTER),
-    ('ReverseX', GEV_REGISTER),
-    ('ReverseY', GEV_REGISTER),
-    ('PixelColorFilter', GEV_REGISTER),
-    ('PixelCoding', GEV_REGISTER),
-    ('PixelSize', GEV_REGISTER),
-    ('PixelFormat', GEV_REGISTER),
-    ('PixelDynamicRangeMin', GEV_REGISTER),
-    ('PixelDynamicRangeMax', GEV_REGISTER),
-    ('TestImageSelector', GEV_REGISTER),
-    ('AcquisitionMode', GEV_REGISTER),
-    ('AcquisitionStart', GEV_REGISTER),
-    ('AcquisitionStop', GEV_REGISTER),
-    ('AcquisitionAbort', GEV_REGISTER),
-    ('AcquisitionArm', GEV_REGISTER),
-    ('AcquisitionFrameCount', GEV_REGISTER),
-    ('AcquisitionFrameRateMax', GEV_REGISTER),
-    ('AcquisitionFrameRateMin', GEV_REGISTER),
-    ('AcquisitionFrameRateRaw', GEV_REGISTER),
-    ('AcquisitionFrameRateAbs', GEV_REGISTER),
-    ('AcquisitionLineRateRaw', GEV_REGISTER),
-    ('AcquisitionLineRateAbs', GEV_REGISTER),
-    ('AcquisitionStatusSelector', GEV_REGISTER),
-    ('AcquisitionStatus', GEV_REGISTER),
-    ('TriggerSelector', GEV_REGISTER),
-    ('TriggerMode', GEV_REGISTER),
-    ('TriggerSoftware', GEV_REGISTER),
-    ('TriggerSource', GEV_REGISTER),
-    ('TriggerActivation', GEV_REGISTER),
-    ('TriggerOverlap', GEV_REGISTER),
-    ('TriggerDelayAbs', GEV_REGISTER),
-    ('TriggerDelayRaw', GEV_REGISTER),
-    ('TriggerDivider', GEV_REGISTER),
-    ('TriggerMultiplier', GEV_REGISTER),
-    ('ExposureMode', GEV_REGISTER),
-    ('ExposureAlignment', GEV_REGISTER),
-    ('ExposureDelay', GEV_REGISTER),
-    ('ExposureTimeRaw', GEV_REGISTER),
-    ('ExposureTimeAbs', GEV_REGISTER),
-    ('ExposureAuto', GEV_REGISTER),
-    ('ExposureTimeMin', GEV_REGISTER),
-    ('ExposureTimeMax', GEV_REGISTER),
-    ('LineSelector', GEV_REGISTER),
-    ('LineMode', GEV_REGISTER),
-    ('LineInverter', GEV_REGISTER),
-    ('LineStatus', GEV_REGISTER),
-    ('LineStatusAll', GEV_REGISTER),
-    ('LineSource', GEV_REGISTER),
-    ('OutputLineEventSource', GEV_REGISTER),
-    ('LineFormat', GEV_REGISTER),
-    ('UserOutputValue', GEV_REGISTER),
-    ('OutputLineValue', GEV_REGISTER),
-    ('UserOutputSelector', GEV_REGISTER),
-    ('UserOutputValueAll', GEV_REGISTER),
-    ('UserOutputValueAllMask', GEV_REGISTER),
-    ('InputLinePolarity', GEV_REGISTER),
-    ('InputLineDebouncingPeriod', GEV_REGISTER),
-    ('OutputLinePulsePolarity', GEV_REGISTER),
-    ('OutputLineMode', GEV_REGISTER),
-    ('OutputLinePulseDelay', GEV_REGISTER),
-    ('OutputLinePulseDuration', GEV_REGISTER),
-    ('CounterSelector', GEV_REGISTER),
-    ('CounterEventSource', GEV_REGISTER),
-    ('CounterLineSource', GEV_REGISTER),
-    ('CounterReset', GEV_REGISTER),
-    ('CounterValue', GEV_REGISTER),
-    ('CounterValueAtReset', GEV_REGISTER),
-    ('CounterDuration', GEV_REGISTER),
-    ('CounterStatus', GEV_REGISTER),
-    ('CounterTriggerSource', GEV_REGISTER),
-    ('CounterTriggerActivation', GEV_REGISTER),
-    ('TimerSelector', GEV_REGISTER),
-    ('TimerDurationAbs', GEV_REGISTER),
-    ('TimerDurationRaw', GEV_REGISTER),
-    ('TimerDelayAbs', GEV_REGISTER),
-    ('TimerDelayRaw', GEV_REGISTER),
-    ('TimerValueAbs', GEV_REGISTER),
-    ('TimerValueRaw', GEV_REGISTER),
-    ('TimerStatus', GEV_REGISTER),
-    ('TimerTriggerSource', GEV_REGISTER),
-    ('TimerTriggerActivation', GEV_REGISTER),
-    ('EventSelector', GEV_REGISTER),
-    ('EventNotification', GEV_REGISTER),
-    ('GainSelector', GEV_REGISTER),
-    ('GainRaw', GEV_REGISTER),
-    ('GainAbs', GEV_REGISTER),
-    ('GainAuto', GEV_REGISTER),
-    ('GainAutoBalance', GEV_REGISTER),
-    ('BlackLevelSelector', GEV_REGISTER),
-    ('BlackLevelRaw', GEV_REGISTER),
-    ('BlackLevelAbs', GEV_REGISTER),
-    ('BlackLevelAuto', GEV_REGISTER),
-    ('BlackLevelAutoBalance', GEV_REGISTER),
-    ('WhiteClipSelector', GEV_REGISTER),
-    ('WhiteClipRaw', GEV_REGISTER),
-    ('WhiteClipAbs', GEV_REGISTER),
-    ('BalanceRatioSelector', GEV_REGISTER),
-    ('BalanceRatioAbs', GEV_REGISTER),
-    ('BalanceWhiteAuto', GEV_REGISTER),
-    ('Gamma', GEV_REGISTER),
-    ('LUTSelector', GEV_REGISTER),
-    ('LUTEnable', GEV_REGISTER),
-    ('LUTIndex', GEV_REGISTER),
-    ('LUTValue', GEV_REGISTER),
-    ('LUTValueAll', GEV_REGISTER),
-    ('UserSetDefaultSelector', GEV_REGISTER),
-    ('UserSetSelector', GEV_REGISTER),
-    ('UserSetLoad', GEV_REGISTER),
-    ('UserSetSave', GEV_REGISTER),
-    ('PayloadSize', GEV_REGISTER),
-    ('GevSupportedIPConfigurationLLA', GEV_REGISTER),
-    ('GevSupportedIPConfigurationDHCP', GEV_REGISTER),
-    ('GevSupportedIPConfigurationPersistentIP', GEV_REGISTER),
-    ('GevCurrentIPConfigurationLLA', GEV_REGISTER),
-    ('GevCurrentIPConfigurationDHCP', GEV_REGISTER),
-    ('GevCurrentIPConfigurationPersistentIP', GEV_REGISTER),
-    ('GevCurrentIPConfiguration', GEV_REGISTER),
-    ('GevCurrentIPAddress', GEV_REGISTER),
-    ('GevCurrentSubnetMask', GEV_REGISTER),
-    ('GevCurrentDefaultGateway', GEV_REGISTER),
-    ('GevPersistentIPAddress', GEV_REGISTER),
-    ('GevPersistentSubnetMask', GEV_REGISTER),
-    ('GevPersistentDefaultGateway', GEV_REGISTER),
-    ('GevFirstURL', GEV_REGISTER),
-    ('GevSecondURL', GEV_REGISTER),
-    ('GevNumberOfInterfaces', GEV_REGISTER),
-    ('GevLinkSpeed', GEV_REGISTER),
-    ('GevIPConfigurationStatus', GEV_REGISTER),
-    ('ChunkModeActive', GEV_REGISTER),
-    ('ChunkSelector', GEV_REGISTER),
-    ('ChunkEnable', GEV_REGISTER),
-    ('ChunkOffsetX', GEV_REGISTER),
-    ('ChunkOffsetY', GEV_REGISTER),
-    ('ChunkWidth', GEV_REGISTER),
-    ('ChunkHeight', GEV_REGISTER),
-    ('ChunkPixelFormat', GEV_REGISTER),
-    ('ChunkDynamicRangeMax', GEV_REGISTER),
-    ('ChunkDynamicRangeMin', GEV_REGISTER),
-    ('ChunkTimestamp', GEV_REGISTER),
-    ('ChunkLineStatusAll', GEV_REGISTER),
-    ('ChunkCounterSelector', GEV_REGISTER),
-    ('ChunkCounter', GEV_REGISTER),
-    ('ChunkTimerSelector', GEV_REGISTER),
-    ('ChunkTimer', GEV_REGISTER),
-    ('FileSelector', GEV_REGISTER),
-    ('FileOperationSelector', GEV_REGISTER),
-    ('FileOperationExecute', GEV_REGISTER),
-    ('FileOpenModeSelector', GEV_REGISTER),
-    ('FileAccessOffset', GEV_REGISTER),
-    ('FileAccessLength', GEV_REGISTER),
-    ('FileAccessBuffer', GEV_REGISTER),
-    ('FileOperationStatus', GEV_REGISTER),
-    ('FileOperationResult', GEV_REGISTER),
-    ('FileSize', GEV_REGISTER),
-]
-
-DALSA_GENICAM_GIGE_REGS = struct_anon_129 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 953
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 962
-if hasattr(_libs['GevApi'], 'GevGetCameraRegisters'):
-    GevGetCameraRegisters = _libs['GevApi'].GevGetCameraRegisters
-    GevGetCameraRegisters.argtypes = [GEV_CAMERA_HANDLE, POINTER(DALSA_GENICAM_GIGE_REGS), c_int]
-    GevGetCameraRegisters.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 963
-if hasattr(_libs['GevApi'], 'GevSetCameraRegInfo'):
-    GevSetCameraRegInfo = _libs['GevApi'].GevSetCameraRegInfo
-    GevSetCameraRegInfo.argtypes = [GEV_CAMERA_HANDLE, cameraType, BOOL, POINTER(DALSA_GENICAM_GIGE_REGS), c_int]
-    GevSetCameraRegInfo.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 965
-if hasattr(_libs['GevApi'], 'GevInitCameraRegisters'):
-    GevInitCameraRegisters = _libs['GevApi'].GevInitCameraRegisters
-    GevInitCameraRegisters.argtypes = [GEV_CAMERA_HANDLE]
-    GevInitCameraRegisters.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 967
-if hasattr(_libs['GevApi'], 'GevGetNumberOfRegisters'):
-    GevGetNumberOfRegisters = _libs['GevApi'].GevGetNumberOfRegisters
-    GevGetNumberOfRegisters.argtypes = [GEV_CAMERA_HANDLE, POINTER(UINT32)]
-    GevGetNumberOfRegisters.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 968
-if hasattr(_libs['GevApi'], 'GevGetRegisterNameByIndex'):
-    GevGetRegisterNameByIndex = _libs['GevApi'].GevGetRegisterNameByIndex
-    GevGetRegisterNameByIndex.argtypes = [GEV_CAMERA_HANDLE, UINT32, c_int, String]
-    GevGetRegisterNameByIndex.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 969
-if hasattr(_libs['GevApi'], 'GevGetRegisterByName'):
-    GevGetRegisterByName = _libs['GevApi'].GevGetRegisterByName
-    GevGetRegisterByName.argtypes = [GEV_CAMERA_HANDLE, String, POINTER(GEV_REGISTER)]
-    GevGetRegisterByName.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 970
-if hasattr(_libs['GevApi'], 'GevGetRegisterPtrByName'):
-    GevGetRegisterPtrByName = _libs['GevApi'].GevGetRegisterPtrByName
-    GevGetRegisterPtrByName.argtypes = [GEV_CAMERA_HANDLE, String, POINTER(POINTER(GEV_REGISTER))]
-    GevGetRegisterPtrByName.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 971
-if hasattr(_libs['GevApi'], 'GevGetRegisterByIndex'):
-    GevGetRegisterByIndex = _libs['GevApi'].GevGetRegisterByIndex
-    GevGetRegisterByIndex.argtypes = [GEV_CAMERA_HANDLE, UINT32, POINTER(GEV_REGISTER)]
-    GevGetRegisterByIndex.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 972
-if hasattr(_libs['GevApi'], 'GevGetRegisterPtrByIndex'):
-    GevGetRegisterPtrByIndex = _libs['GevApi'].GevGetRegisterPtrByIndex
-    GevGetRegisterPtrByIndex.argtypes = [GEV_CAMERA_HANDLE, UINT32, POINTER(POINTER(GEV_REGISTER))]
-    GevGetRegisterPtrByIndex.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 974
-if hasattr(_libs['GevApi'], 'GevReadRegisterByName'):
-    GevReadRegisterByName = _libs['GevApi'].GevReadRegisterByName
-    GevReadRegisterByName.argtypes = [GEV_CAMERA_HANDLE, String, c_int, UINT32, POINTER(None)]
-    GevReadRegisterByName.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 975
-if hasattr(_libs['GevApi'], 'GevWriteRegisterByName'):
-    GevWriteRegisterByName = _libs['GevApi'].GevWriteRegisterByName
-    GevWriteRegisterByName.argtypes = [GEV_CAMERA_HANDLE, String, c_int, UINT32, POINTER(None)]
-    GevWriteRegisterByName.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 977
-if hasattr(_libs['GevApi'], 'GevRegisterRead'):
-    GevRegisterRead = _libs['GevApi'].GevRegisterRead
-    GevRegisterRead.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32, POINTER(None)]
-    GevRegisterRead.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 978
-if hasattr(_libs['GevApi'], 'GevRegisterWrite'):
-    GevRegisterWrite = _libs['GevApi'].GevRegisterWrite
-    GevRegisterWrite.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32, POINTER(None)]
-    GevRegisterWrite.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 979
-if hasattr(_libs['GevApi'], 'GevRegisterWriteNoWait'):
-    GevRegisterWriteNoWait = _libs['GevApi'].GevRegisterWriteNoWait
-    GevRegisterWriteNoWait.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32, POINTER(None)]
-    GevRegisterWriteNoWait.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 981
-if hasattr(_libs['GevApi'], 'GevRegisterWriteArray'):
-    GevRegisterWriteArray = _libs['GevApi'].GevRegisterWriteArray
-    GevRegisterWriteArray.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32, UINT32, POINTER(None)]
-    GevRegisterWriteArray.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 982
-if hasattr(_libs['GevApi'], 'GevRegisterReadArray'):
-    GevRegisterReadArray = _libs['GevApi'].GevRegisterReadArray
-    GevRegisterReadArray.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32, UINT32, POINTER(None)]
-    GevRegisterReadArray.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 984
-if hasattr(_libs['GevApi'], 'GevRegisterWriteInt'):
-    GevRegisterWriteInt = _libs['GevApi'].GevRegisterWriteInt
-    GevRegisterWriteInt.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, UINT32]
-    GevRegisterWriteInt.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 985
-if hasattr(_libs['GevApi'], 'GevRegisterReadInt'):
-    GevRegisterReadInt = _libs['GevApi'].GevRegisterReadInt
-    GevRegisterReadInt.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, POINTER(UINT32)]
-    GevRegisterReadInt.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 986
-if hasattr(_libs['GevApi'], 'GevRegisterWriteFloat'):
-    GevRegisterWriteFloat = _libs['GevApi'].GevRegisterWriteFloat
-    GevRegisterWriteFloat.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, c_float]
-    GevRegisterWriteFloat.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 987
-if hasattr(_libs['GevApi'], 'GevRegisterReadFloat'):
-    GevRegisterReadFloat = _libs['GevApi'].GevRegisterReadFloat
-    GevRegisterReadFloat.argtypes = [GEV_CAMERA_HANDLE, POINTER(GEV_REGISTER), c_int, POINTER(c_float)]
-    GevRegisterReadFloat.restype = GEV_STATUS
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 46
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 680
+for _lib in _libs.itervalues():
+    if not hasattr(_lib, 'ConvertBayerToRGB'):
+        continue
+    ConvertBayerToRGB = _lib.ConvertBayerToRGB
+    ConvertBayerToRGB.argtypes = [c_int, UINT32, UINT32, UINT32, POINTER(None), UINT32, POINTER(None)]
+    ConvertBayerToRGB.restype = GEV_STATUS
+    break
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 683
+if hasattr(_libs['GevApi'], 'Gev_UnpackMonoPackedFrame'):
+    Gev_UnpackMonoPackedFrame = _libs['GevApi'].Gev_UnpackMonoPackedFrame
+    Gev_UnpackMonoPackedFrame.argtypes = [UINT32, UINT32, POINTER(None), UINT32, POINTER(None)]
+    Gev_UnpackMonoPackedFrame.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 686
+if hasattr(_libs['GevApi'], 'Gev_DecodeTurboDriveFrame'):
+    Gev_DecodeTurboDriveFrame = _libs['GevApi'].Gev_DecodeTurboDriveFrame
+    Gev_DecodeTurboDriveFrame.argtypes = [UINT32, UINT32, UINT32, UINT32, UINT32, UINT64, POINTER(None), UINT64, POINTER(None), POINTER(UINT64), POINTER(UINT64)]
+    Gev_DecodeTurboDriveFrame.restype = GEV_STATUS
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 46
 try:
     GENICAM_TARGET_ROOT_VERSION = 'GENICAM_ROOT_V3_0'
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 47
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 47
 try:
     GIGEV_XML_DOWNLOAD = 'GIGEV_XML_DOWNLOAD'
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 65
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 65
 try:
     GEV_LOG_LEVEL_OFF = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 66
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 66
 try:
     GEV_LOG_LEVEL_NORMAL = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 67
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 67
 try:
     GEV_LOG_LEVEL_ERRORS = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 68
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 68
 try:
     GEV_LOG_LEVEL_WARNINGS = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 69
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 69
 try:
     GEV_LOG_LEVEL_DEBUG = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 70
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 70
 try:
     GEV_LOG_LEVEL_TRACE = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 72
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 72
 try:
     GEV_LOG_FATAL = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 73
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 73
 try:
     GEV_LOG_ERROR = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 74
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 74
 try:
     GEV_LOG_WARNING = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 75
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 75
 try:
     GEV_LOG_INFO = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 76
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 76
+try:
+    GEV_LOG_DEBUG = 3
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 77
 try:
     GEV_LOG_TRACE = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 81
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 82
 try:
     GEVLIB_OK = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 82
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 83
 try:
     GEVLIB_SUCCESS = GEVLIB_OK
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 83
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 84
 try:
     GEVLIB_STATUS_SUCCESS = GEVLIB_OK
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 84
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 85
 try:
     GEVLIB_STATUS_ERROR = (-1)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 87
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 88
 try:
     GEVLIB_ERROR_GENERIC = (-1)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 88
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 89
 try:
     GEVLIB_ERROR_NULL_PTR = (-2)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 89
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 90
 try:
     GEVLIB_ERROR_ARG_INVALID = (-3)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 90
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 91
 try:
     GEVLIB_ERROR_INVALID_HANDLE = (-4)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 91
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 92
 try:
     GEVLIB_ERROR_NOT_SUPPORTED = (-5)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 92
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 93
 try:
     GEVLIB_ERROR_TIME_OUT = (-6)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 93
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 94
 try:
     GEVLIB_ERROR_NOT_IMPLEMENTED = (-10)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 94
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 95
 try:
     GEVLIB_ERROR_NO_CAMERA = (-11)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 95
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 96
 try:
     GEVLIB_ERROR_INVALID_PIXEL_FORMAT = (-12)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 96
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 97
 try:
     GEVLIB_ERROR_PARAMETER_INVALID = (-13)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 97
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 98
 try:
     GEVLIB_ERROR_SOFTWARE = (-14)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 98
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 99
 try:
     GEVLIB_ERROR_API_NOT_INITIALIZED = (-15)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 99
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 100
 try:
     GEVLIB_ERROR_DEVICE_NOT_FOUND = (-16)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 100
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 101
 try:
     GEVLIB_ERROR_ACCESS_DENIED = (-17)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 101
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 102
 try:
     GEVLIB_ERROR_NOT_AVAILABLE = (-18)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 102
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 103
 try:
     GEVLIB_ERROR_NO_SPACE = (-19)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 105
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 104
+try:
+    GEVLIB_ERROR_XFER_NOT_INITIALIZED = (-20)
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 105
+try:
+    GEVLIB_ERROR_XFER_ACTIVE = (-21)
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 106
+try:
+    GEVLIB_ERROR_XFER_NOT_ACTIVE = (-22)
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 109
 try:
     GEVLIB_ERROR_SYSTEM_RESOURCE = (-2001)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 106
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 110
 try:
     GEVLIB_ERROR_INSUFFICIENT_MEMORY = (-2002)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 107
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 111
 try:
     GEVLIB_ERROR_INSUFFICIENT_BANDWIDTH = (-2003)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 108
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 112
 try:
     GEVLIB_ERROR_RESOURCE_NOT_ALLOCATED = (-2004)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 109
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 113
 try:
     GEVLIB_ERROR_RESOURCE_IN_USE = (-2005)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 110
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 114
 try:
     GEVLIB_ERROR_RESOURCE_NOT_ENABLED = (-2006)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 111
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 115
 try:
     GEVLIB_ERROR_RESOURCE_NOT_INITIALIZED = (-2007)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 112
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 116
 try:
     GEVLIB_ERROR_RESOURCE_CORRUPTED = (-2008)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 113
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 117
 try:
     GEVLIB_ERROR_RESOURCE_MISSING = (-2009)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 114
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 118
 try:
     GEVLIB_ERROR_RESOURCE_LACK = (-2010)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 115
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 119
 try:
     GEVLIB_ERROR_RESOURCE_ACCESS = (-2011)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 116
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 120
 try:
     GEVLIB_ERROR_RESOURCE_INVALID = (-2012)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 117
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 121
 try:
     GEVLIB_ERROR_RESOURCE_LOCK = (-2013)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 118
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 122
 try:
     GEVLIB_ERROR_INSUFFICIENT_PRIVILEGE = (-2014)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 119
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 123
 try:
     GEVLIB_ERROR_RESOURCE_WRITE_PROTECTED = (-2015)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 120
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 124
 try:
     GEVLIB_ERROR_RESOURCE_INCOHERENCY = (-2016)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 123
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 127
 try:
     GEVLIB_ERROR_DATA_NO_MESSAGES = (-5001)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 124
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 128
 try:
     GEVLIB_ERROR_DATA_OVERFLOW = (-5002)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 125
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 129
 try:
     GEVLIB_ERROR_DATA_CHECKSUM = (-5003)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 126
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 130
 try:
     GEVLIB_ERROR_DATA_NOT_AVAILABLE = (-5004)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 127
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 131
 try:
     GEVLIB_ERROR_DATA_OVERRUN = (-5005)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 128
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 132
 try:
     GEVLIB_ERROR_DATA_XFER_ABORT = (-5006)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 129
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 133
 try:
     GEVLIB_ERROR_DATA_INVALID_HEADER = (-5007)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 130
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 134
 try:
     GEVLIB_ERROR_DATA_ALIGNMENT = (-5008)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 133
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 137
 try:
     GEVLIB_ERROR_CONNECTION_DROPPED = (-11000)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 134
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 138
 try:
     GEVLIB_ERROR_ANSWER_TIMEOUT = (-11001)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 135
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 139
 try:
     GEVLIB_ERROR_SOCKET_INVALID = (-11002)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 136
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 140
 try:
     GEVLIB_ERROR_PORT_NOT_AVAILABLE = (-11003)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 137
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 141
 try:
     GEVLIB_ERROR_INVALID_IP = (-11004)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 138
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 142
 try:
     GEVLIB_ERROR_INVALID_CAMERA_OPERATION = (-11005)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 139
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 143
 try:
     GEVLIB_ERROR_INVALID_PACKET = (-11006)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 140
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 144
 try:
     GEVLIB_ERROR_INVALID_CONNECTION_ATTEMPT = (-11007)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 141
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 145
 try:
     GEVLIB_ERROR_PROTOCOL = (-11008)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 142
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 146
 try:
     GEVLIB_ERROR_WINDOWS_SOCKET_INIT = (-11009)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 143
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 147
 try:
     GEVLIB_ERROR_WINDOWS_SOCKET_CLOSE = (-11010)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 144
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 148
 try:
     GEVLIB_ERROR_SOCKET_CREATE = (-11011)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 145
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 149
 try:
     GEVLIB_ERROR_SOCKET_RELEASE = (-11012)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 146
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 150
 try:
     GEVLIB_ERROR_SOCKET_DATA_SEND = (-11013)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 147
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 151
 try:
     GEVLIB_ERROR_SOCKET_DATA_READ = (-11014)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 148
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 152
 try:
     GEVLIB_ERROR_SOCKET_WAIT_ACKNOWLEDGE = (-11015)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 149
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 153
 try:
     GEVLIB_ERROR_INVALID_INTERNAL_COMMAND = (-11016)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 150
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 154
 try:
     GEVLIB_ERROR_INVALID_ACKNOWLEDGE = (-11017)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 151
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 155
 try:
     GEVLIB_ERROR_PREVIOUS_ACKNOWLEDGE = (-11018)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 152
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 156
 try:
     GEVLIB_ERROR_INVALID_MESSAGE = (-11019)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 153
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 157
 try:
     GEVLIB_ERROR_GIGE_ERROR = (-11020)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 159
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 163
 try:
     GEV_STATUS_SUCCESS = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 160
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 164
 try:
     GEV_STATUS_NOT_IMPLEMENTED = 32769
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 161
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 165
 try:
     GEV_STATUS_INVALID_PARAMETER = 32770
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 162
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 166
 try:
     GEV_STATUS_INVALID_ADDRESS = 32771
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 163
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 167
 try:
     GEV_STATUS_WRITE_PROTECT = 32772
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 164
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 168
 try:
     GEV_STATUS_BAD_ALIGNMENT = 32773
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 165
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 169
 try:
     GEV_STATUS_ACCESS_DENIED = 32774
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 166
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 170
 try:
     GEV_STATUS_BUSY = 32775
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 167
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 171
 try:
     GEV_STATUS_LOCAL_PROBLEM = 32776
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 168
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 172
 try:
     GEV_STATUS_MSG_MISMATCH = 32777
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 169
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 173
 try:
     GEV_STATUS_INVALID_PROTOCOL = 32778
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 170
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 174
 try:
     GEV_STATUS_NO_MSG = 32779
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 171
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 175
 try:
     GEV_STATUS_PACKET_UNAVAILABLE = 32780
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 172
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 176
 try:
     GEV_STATUS_DATA_OVERRUN = 32781
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 173
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 177
 try:
     GEV_STATUS_INVALID_HEADER = 32782
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 175
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 179
 try:
     GEV_STATUS_ERROR = 36863
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 233
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 251
 try:
     GEV_PIXFORMAT_ISMONO = 16777216
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 234
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 252
 try:
     GEV_PIXFORMAT_ISCOLOR = 33554432
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 235
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 253
 try:
     GEV_PIXFORMAT_ISCUSTOM = 2147483648
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 237
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 255
 try:
     GEV_PIXEL_FORMAT_MONO = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 238
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 256
 try:
     GEV_PIXEL_FORMAT_MONO_PACKED = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 239
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 257
 try:
     GEV_PIXEL_FORMAT_RGB = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 240
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 258
 try:
     GEV_PIXEL_FORMAT_RGB_PACKED = 8
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 241
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 259
 try:
     GEV_PIXEL_FORMAT_BAYER = 16
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 242
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 260
 try:
     GEV_PIXEL_FORMAT_YUV = 32
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 243
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 261
 try:
     GEV_PIXEL_FORMAT_RGB_PLANAR = 64
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 245
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 263
 try:
     GEV_PIXEL_ORDER_NONE = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 246
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 264
 try:
     GEV_PIXEL_ORDER_RGB = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 247
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 265
 try:
     GEV_PIXEL_ORDER_BGR = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 248
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 266
 try:
     GEV_PIXEL_ORDER_GRB = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 249
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 267
 try:
     GEV_PIXEL_ORDER_GBR = 8
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 250
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 268
 try:
     GEV_PIXEL_ORDER_RGB10V1 = 61440
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 251
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 269
 try:
     GEV_PIXEL_ORDER_RGB10V2 = 57344
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 314
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 344
 try:
     MAX_GEVSTRING_LENGTH = 64
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 356
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 401
 try:
     GEV_FRAME_STATUS_RECVD = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 357
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 402
 try:
     GEV_FRAME_STATUS_PENDING = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 358
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 403
 try:
     GEV_FRAME_STATUS_TIMEOUT = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 359
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 404
 try:
     GEV_FRAME_STATUS_OVERFLOW = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 360
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 405
 try:
     GEV_FRAME_STATUS_BANDWIDTH = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 361
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 406
 try:
     GEV_FRAME_STATUS_LOST = 5
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 362
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 407
 try:
     GEV_FRAME_STATUS_RELEASED = (-1)
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 471
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 517
 try:
     GENAPI_UNUSED_TYPE = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 472
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 518
 try:
     GENAPI_VALUE_TYPE = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 473
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 519
 try:
     GENAPI_BASE_TYPE = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 474
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 520
 try:
     GENAPI_INTEGER_TYPE = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 475
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 521
 try:
     GENAPI_BOOLEAN_TYPE = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 476
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 522
 try:
     GENAPI_COMMAND_TYPE = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 477
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 523
 try:
     GENAPI_FLOAT_TYPE = 5
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 478
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 524
 try:
     GENAPI_STRING_TYPE = 6
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 479
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 525
 try:
     GENAPI_REGISTER_TYPE = 7
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 480
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 526
 try:
     GENAPI_CATEGORY_TYPE = 8
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 481
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 527
 try:
     GENAPI_ENUM_TYPE = 9
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 482
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 528
 try:
     GENAPI_ENUMENTRY_TYPE = 10
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 485
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 531
 try:
     GENAPI_ACCESSMODE_NI = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 486
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 532
 try:
     GENAPI_ACCESSMODE_NA = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 487
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 533
 try:
     GENAPI_ACCESSMODE_WO = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 488
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 534
 try:
     GENAPI_ACCESSMODE_RO = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 489
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 535
 try:
     GENAPI_ACCESSMODE_RW = 4
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 490
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 536
 try:
     GENAPI_ACCESSMODE_NONE = 5
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 493
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 539
 try:
     GENAPI_VISIBILITY_BEGINNER = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 494
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 540
 try:
     GENAPI_VISIBILITY_EXPERT = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 495
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 541
 try:
     GENAPI_VISIBILITY_GURU = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 496
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 542
 try:
     GENAPI_VISIBILITY_INVISIBLE = 3
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 497
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 543
 try:
     GENAPI_VISIBILITY_UNDEFINED = 99
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 500
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 546
 try:
     GENAPI_INCREMENT_NONE = 0
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 501
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 547
 try:
     GENAPI_INCREMENT_FIXED = 1
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 502
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 548
 try:
     GENAPI_INCREMENT_LIST = 2
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 634
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 644
 try:
-    FEATURE_NAME_MAX_SIZE = 64
+    GevFreeImageTransfer = GevFreeTransfer
 except:
     pass
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 635
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 645
 try:
-    NOREF_ADDR = 0
+    GevStartImageTransfer = GevStartTransfer
 except:
     pass
 
-_tag_GEVBUF_ENTRY = struct__tag_GEVBUF_ENTRY # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 354
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 646
+try:
+    GevStopImageTransfer = GevStopTransfer
+except:
+    pass
 
-_GEVBUF_QUEUE = struct__GEVBUF_QUEUE # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevapi.h: 388
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 647
+try:
+    GevAbortImageTransfer = GevAbortTransfer
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 648
+try:
+    GevQueryImageTransferStatus = GevQueryTransferStatus
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 657
+try:
+    GevGetNextImage = GevGetNextFrame
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 658
+try:
+    GevWaitForNextImage = GevWaitForNextFrame
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 659
+try:
+    GevReleaseImage = GevReleaseFrame
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 660
+try:
+    GevReleaseImageBuffer = GevReleaseFrameBuffer
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 674
+try:
+    BAYER_ALIGN_GB_RG = 0
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 675
+try:
+    BAYER_ALIGN_BG_GR = 1
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 676
+try:
+    BAYER_ALIGN_RG_GB = 2
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 677
+try:
+    BAYER_ALIGN_GR_BG = 3
+except:
+    pass
+
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 679
+try:
+    BAYER_CONVERSION_2X2 = 0
+except:
+    pass
+
+_tag_GEVBUF_ENTRY = struct__tag_GEVBUF_ENTRY # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 399
+
+_GEVBUF_QUEUE = struct__GEVBUF_QUEUE # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevapi.h: 438
 
 # No inserted files
 

--- a/src/rpi_gige_v_framework/gevoslib.py
+++ b/src/rpi_gige_v_framework/gevoslib.py
@@ -1,7 +1,7 @@
 '''Wrapper for gevoslib.h
 
 Generated with:
-/home/wasonj/.local/bin/ctypesgen.py -lGevApi gevoslib.h -o gevoslib.py
+ctypesgen.py -lGevApi /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h -o gevoslib.py
 
 Do not modify this file.
 '''
@@ -594,15 +594,15 @@ _libs["GevApi"] = load_library("GevApi")
 
 # No modules
 
-__time_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 139
+__time_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 148
 
-__suseconds_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 141
+__suseconds_t = c_long # /usr/include/x86_64-linux-gnu/bits/types.h: 150
 
-u_int16_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 174
+u_int16_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 162
 
-u_int32_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 175
+u_int32_t = c_uint # /usr/include/x86_64-linux-gnu/sys/types.h: 163
 
-# /usr/include/x86_64-linux-gnu/bits/time.h: 30
+# /usr/include/x86_64-linux-gnu/bits/types/struct_timeval.h: 8
 class struct_timeval(Structure):
     pass
 
@@ -615,9 +615,7 @@ struct_timeval._fields_ = [
     ('tv_usec', __suseconds_t),
 ]
 
-pthread_t = c_ulong # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 60
-
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 75
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 82
 class struct___pthread_internal_list(Structure):
     pass
 
@@ -630,9 +628,9 @@ struct___pthread_internal_list._fields_ = [
     ('__next', POINTER(struct___pthread_internal_list)),
 ]
 
-__pthread_list_t = struct___pthread_internal_list # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 79
+__pthread_list_t = struct___pthread_internal_list # /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 86
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 92
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 118
 class struct___pthread_mutex_s(Structure):
     pass
 
@@ -657,24 +655,43 @@ struct___pthread_mutex_s._fields_ = [
     ('__list', __pthread_list_t),
 ]
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 128
+# /usr/include/x86_64-linux-gnu/bits/thread-shared-types.h: 151
+class struct___pthread_cond_s(Structure):
+    pass
+
+struct___pthread_cond_s.__slots__ = [
+    '__g_refs',
+    '__g_size',
+    '__g1_orig_size',
+    '__wrefs',
+    '__g_signals',
+]
+struct___pthread_cond_s._fields_ = [
+    ('__g_refs', c_uint * 2),
+    ('__g_size', c_uint * 2),
+    ('__g1_orig_size', c_uint),
+    ('__wrefs', c_uint),
+    ('__g_signals', c_uint * 2),
+]
+
+pthread_t = c_ulong # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 27
+
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 36
 class union_anon_9(Union):
     pass
 
 union_anon_9.__slots__ = [
-    '__data',
     '__size',
     '__align',
 ]
 union_anon_9._fields_ = [
-    ('__data', struct___pthread_mutex_s),
-    ('__size', c_char * 40),
-    ('__align', c_long),
+    ('__size', c_char * 4),
+    ('__align', c_int),
 ]
 
-pthread_mutex_t = union_anon_9 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 128
+pthread_mutexattr_t = union_anon_9 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 36
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 134
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 45
 class union_anon_10(Union):
     pass
 
@@ -687,34 +704,26 @@ union_anon_10._fields_ = [
     ('__align', c_int),
 ]
 
-pthread_mutexattr_t = union_anon_10 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 134
+pthread_condattr_t = union_anon_10 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 45
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 141
-class struct_anon_11(Structure):
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 72
+class union_anon_11(Union):
     pass
 
-struct_anon_11.__slots__ = [
-    '__lock',
-    '__futex',
-    '__total_seq',
-    '__wakeup_seq',
-    '__woken_seq',
-    '__mutex',
-    '__nwaiters',
-    '__broadcast_seq',
+union_anon_11.__slots__ = [
+    '__data',
+    '__size',
+    '__align',
 ]
-struct_anon_11._fields_ = [
-    ('__lock', c_int),
-    ('__futex', c_uint),
-    ('__total_seq', c_ulonglong),
-    ('__wakeup_seq', c_ulonglong),
-    ('__woken_seq', c_ulonglong),
-    ('__mutex', POINTER(None)),
-    ('__nwaiters', c_uint),
-    ('__broadcast_seq', c_uint),
+union_anon_11._fields_ = [
+    ('__data', struct___pthread_mutex_s),
+    ('__size', c_char * 40),
+    ('__align', c_long),
 ]
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 154
+pthread_mutex_t = union_anon_11 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 72
+
+# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 80
 class union_anon_12(Union):
     pass
 
@@ -724,39 +733,24 @@ union_anon_12.__slots__ = [
     '__align',
 ]
 union_anon_12._fields_ = [
-    ('__data', struct_anon_11),
+    ('__data', struct___pthread_cond_s),
     ('__size', c_char * 48),
     ('__align', c_longlong),
 ]
 
-pthread_cond_t = union_anon_12 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 154
+pthread_cond_t = union_anon_12 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 80
 
-# /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 160
-class union_anon_13(Union):
-    pass
+UINT16 = u_int16_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 801
 
-union_anon_13.__slots__ = [
-    '__size',
-    '__align',
-]
-union_anon_13._fields_ = [
-    ('__size', c_char * 4),
-    ('__align', c_int),
-]
+UINT32 = u_int32_t # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/cordef.h: 803
 
-pthread_condattr_t = union_anon_13 # /usr/include/x86_64-linux-gnu/bits/pthreadtypes.h: 160
+BOOL = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/posixcmn.h: 166
 
-UINT16 = u_int16_t # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 801
+enum_anon_89 = c_int # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 191
 
-UINT32 = u_int32_t # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/cordef.h: 803
+MutexType_t = enum_anon_89 # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 191
 
-BOOL = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/posixcmn.h: 166
-
-enum_anon_91 = c_int # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 191
-
-MutexType_t = enum_anon_91 # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 191
-
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 204
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 204
 class struct__CRITICAL_SECTION(Structure):
     pass
 
@@ -783,41 +777,41 @@ struct__CRITICAL_SECTION._fields_ = [
     ('savedThreadCancelState', c_int),
 ]
 
-CRITICAL_SECTION = struct__CRITICAL_SECTION # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 204
+CRITICAL_SECTION = struct__CRITICAL_SECTION # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 204
 
-HANDLE = POINTER(None) # /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/corposix.h: 237
+HANDLE = POINTER(None) # /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/corposix.h: 237
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 68
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 68
 if hasattr(_libs['GevApi'], '_InitSocketAPI'):
     _InitSocketAPI = _libs['GevApi']._InitSocketAPI
     _InitSocketAPI.argtypes = []
     _InitSocketAPI.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 69
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 69
 if hasattr(_libs['GevApi'], '_CloseSocketAPI'):
     _CloseSocketAPI = _libs['GevApi']._CloseSocketAPI
     _CloseSocketAPI.argtypes = []
     _CloseSocketAPI.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 70
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 70
 if hasattr(_libs['GevApi'], '_GetSocketError'):
     _GetSocketError = _libs['GevApi']._GetSocketError
     _GetSocketError.argtypes = []
     _GetSocketError.restype = c_int
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 73
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 73
 if hasattr(_libs['GevApi'], '_GetMaxNetworkInterfaces'):
     _GetMaxNetworkInterfaces = _libs['GevApi']._GetMaxNetworkInterfaces
     _GetMaxNetworkInterfaces.argtypes = []
     _GetMaxNetworkInterfaces.restype = c_int
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 74
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 74
 if hasattr(_libs['GevApi'], '_GetMacAddress'):
     _GetMacAddress = _libs['GevApi']._GetMacAddress
     _GetMacAddress.argtypes = [c_int, POINTER(UINT16), POINTER(UINT32), POINTER(UINT32), POINTER(UINT32)]
     _GetMacAddress.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 75
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 75
 for _lib in _libs.itervalues():
     if not hasattr(_lib, '_SetIPAddress'):
         continue
@@ -826,163 +820,163 @@ for _lib in _libs.itervalues():
     _SetIPAddress.restype = BOOL
     break
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 76
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 76
 if hasattr(_libs['GevApi'], '_GetMTUSetting'):
     _GetMTUSetting = _libs['GevApi']._GetMTUSetting
     _GetMTUSetting.argtypes = [c_int, POINTER(c_int)]
     _GetMTUSetting.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 79
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 79
 if hasattr(_libs['GevApi'], '_CreateEvent'):
     _CreateEvent = _libs['GevApi']._CreateEvent
     _CreateEvent.argtypes = [POINTER(HANDLE)]
     _CreateEvent.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 80
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 80
 if hasattr(_libs['GevApi'], '_DestroyEvent'):
     _DestroyEvent = _libs['GevApi']._DestroyEvent
     _DestroyEvent.argtypes = [POINTER(HANDLE)]
     _DestroyEvent.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 81
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 81
 if hasattr(_libs['GevApi'], '_WaitForEvent'):
     _WaitForEvent = _libs['GevApi']._WaitForEvent
     _WaitForEvent.argtypes = [POINTER(HANDLE), UINT32]
     _WaitForEvent.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 82
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 82
 if hasattr(_libs['GevApi'], '_ClearEvent'):
     _ClearEvent = _libs['GevApi']._ClearEvent
     _ClearEvent.argtypes = [POINTER(HANDLE)]
     _ClearEvent.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 83
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 83
 if hasattr(_libs['GevApi'], '_SetEvent'):
     _SetEvent = _libs['GevApi']._SetEvent
     _SetEvent.argtypes = [POINTER(HANDLE)]
     _SetEvent.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 86
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 86
 if hasattr(_libs['GevApi'], '_CreateMutex'):
     _CreateMutex = _libs['GevApi']._CreateMutex
     _CreateMutex.argtypes = [POINTER(pthread_mutex_t)]
     _CreateMutex.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 87
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 87
 if hasattr(_libs['GevApi'], '_DestroyMutex'):
     _DestroyMutex = _libs['GevApi']._DestroyMutex
     _DestroyMutex.argtypes = [POINTER(pthread_mutex_t)]
     _DestroyMutex.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 88
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 88
 if hasattr(_libs['GevApi'], '_AcquireMutex'):
     _AcquireMutex = _libs['GevApi']._AcquireMutex
     _AcquireMutex.argtypes = [POINTER(pthread_mutex_t), UINT32]
     _AcquireMutex.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 89
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 89
 if hasattr(_libs['GevApi'], '_ReleaseMutex'):
     _ReleaseMutex = _libs['GevApi']._ReleaseMutex
     _ReleaseMutex.argtypes = [POINTER(pthread_mutex_t)]
     _ReleaseMutex.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 92
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 92
 if hasattr(_libs['GevApi'], '_InitCriticalSection'):
     _InitCriticalSection = _libs['GevApi']._InitCriticalSection
     _InitCriticalSection.argtypes = [POINTER(CRITICAL_SECTION)]
     _InitCriticalSection.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 93
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 93
 if hasattr(_libs['GevApi'], '_ReleaseCriticalSection'):
     _ReleaseCriticalSection = _libs['GevApi']._ReleaseCriticalSection
     _ReleaseCriticalSection.argtypes = [POINTER(CRITICAL_SECTION)]
     _ReleaseCriticalSection.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 94
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 94
 if hasattr(_libs['GevApi'], '_EnterCriticalSection'):
     _EnterCriticalSection = _libs['GevApi']._EnterCriticalSection
     _EnterCriticalSection.argtypes = [POINTER(CRITICAL_SECTION)]
     _EnterCriticalSection.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 95
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 95
 if hasattr(_libs['GevApi'], '_LeaveCriticalSection'):
     _LeaveCriticalSection = _libs['GevApi']._LeaveCriticalSection
     _LeaveCriticalSection.argtypes = [POINTER(CRITICAL_SECTION)]
     _LeaveCriticalSection.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 99
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 99
 if hasattr(_libs['GevApi'], '_CreateThread'):
     _CreateThread = _libs['GevApi']._CreateThread
     _CreateThread.argtypes = [CFUNCTYPE(UNCHECKED(c_uint), POINTER(None)), POINTER(None), c_int, POINTER(HANDLE)]
     _CreateThread.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 100
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 100
 if hasattr(_libs['GevApi'], '_WaitForThread'):
     _WaitForThread = _libs['GevApi']._WaitForThread
     _WaitForThread.argtypes = [POINTER(HANDLE), UINT32]
     _WaitForThread.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 101
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 101
 if hasattr(_libs['GevApi'], '_GetNumCpus'):
     _GetNumCpus = _libs['GevApi']._GetNumCpus
     _GetNumCpus.argtypes = []
     _GetNumCpus.restype = c_int
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 104
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 104
 if hasattr(_libs['GevApi'], '_IsTimedOut'):
     _IsTimedOut = _libs['GevApi']._IsTimedOut
     _IsTimedOut.argtypes = [POINTER(struct_timeval)]
     _IsTimedOut.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 105
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 105
 if hasattr(_libs['GevApi'], '_GetTimeOut'):
     _GetTimeOut = _libs['GevApi']._GetTimeOut
     _GetTimeOut.argtypes = [c_int, POINTER(struct_timeval)]
     _GetTimeOut.restype = None
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 108
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 108
 if hasattr(_libs['GevApi'], '_Wait'):
     _Wait = _libs['GevApi']._Wait
     _Wait.argtypes = [UINT32]
     _Wait.restype = None
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 109
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 109
 if hasattr(_libs['GevApi'], '_GetTimestamp'):
     _GetTimestamp = _libs['GevApi']._GetTimestamp
     _GetTimestamp.argtypes = [POINTER(UINT32), POINTER(UINT32)]
     _GetTimestamp.restype = BOOL
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 110
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 110
 if hasattr(_libs['GevApi'], '_Convert_to_LEFeature_Order'):
     _Convert_to_LEFeature_Order = _libs['GevApi']._Convert_to_LEFeature_Order
     _Convert_to_LEFeature_Order.argtypes = [UINT32]
     _Convert_to_LEFeature_Order.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 111
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 111
 if hasattr(_libs['GevApi'], '_Convert_from_LEFeature_Order'):
     _Convert_from_LEFeature_Order = _libs['GevApi']._Convert_from_LEFeature_Order
     _Convert_from_LEFeature_Order.argtypes = [UINT32]
     _Convert_from_LEFeature_Order.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 112
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 112
 if hasattr(_libs['GevApi'], '_CPU_to_LE32'):
     _CPU_to_LE32 = _libs['GevApi']._CPU_to_LE32
     _CPU_to_LE32.argtypes = [UINT32]
     _CPU_to_LE32.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 113
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 113
 if hasattr(_libs['GevApi'], '_LE32_to_CPU'):
     _LE32_to_CPU = _libs['GevApi']._LE32_to_CPU
     _LE32_to_CPU.argtypes = [UINT32]
     _LE32_to_CPU.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 114
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 114
 if hasattr(_libs['GevApi'], '_CPU_to_BE32'):
     _CPU_to_BE32 = _libs['GevApi']._CPU_to_BE32
     _CPU_to_BE32.argtypes = [UINT32]
     _CPU_to_BE32.restype = UINT32
 
-# /home/wasonj/Downloads/GigE-V-Framework_2.02.0.0132/DALSA/GigeV/include/gevoslib.h: 115
+# /home/david/GigE-V-Framework_2.10.0.0157/DALSA/GigeV/include/gevoslib.h: 115
 if hasattr(_libs['GevApi'], '_BE32_to_CPU'):
     _BE32_to_CPU = _libs['GevApi']._BE32_to_CPU
     _BE32_to_CPU.argtypes = [UINT32]

--- a/src/rpi_gige_v_framework/rpi_gige_v_framework.py
+++ b/src/rpi_gige_v_framework/rpi_gige_v_framework.py
@@ -162,6 +162,9 @@ class GigE_V_VideoCapture(object):
         if (self._camera is not None):
             gevapi.GevCloseCamera(self._camera)            
             self._camera=None
+            gevapi.GevStopImageTransfer(-1)  # not working at the moment
+            gevapi.GevAbortImageTransfer() # not working at the moment
+            gevapi.GevReleaseImageBuffer()
             
 
     def read(self):


### PR DESCRIPTION
Corrected .py files to work with the latest version of the GevApi libray
and new "ros_image_publisher" node to publish the images in a ros `sensor_msgs/Image` msg.